### PR TITLE
fix: preserve main hierarchy across route navigation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,5 +95,13 @@ let package = Package(
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault")
             ]
         ),
+        .testTarget(
+            name: "RunBotTests",
+            dependencies: ["RunBot"],
+            path: "Tests/RunBotTests",
+            swiftSettings: [
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+            ]
+        ),
     ]
 )

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -193,6 +193,13 @@ final class AppState {
     /// preserves it; explicit Back navigation clears it to return to Main.
     var savedNavState: NavState?
 
+    /// Process-lifetime hierarchy state for the Main panel route.
+    ///
+    /// Preserves workflow and nested-job expansion state across Settings,
+    /// Step Log, and panel hide/unhide. Never reset by navigateBack() or
+    /// closePanel(). Never persisted to UserDefaults.
+    let mainHierarchyState = MainHierarchyState()
+
     /// Single `DiskZIPCache` instance shared between `LogFetcher` and
     /// `RunnerPoller` so that ZIPs prefetched by the poller are immediately
     /// available to the log fetcher without a second network round-trip.

--- a/Sources/RunBot/App/MainHierarchyState.swift
+++ b/Sources/RunBot/App/MainHierarchyState.swift
@@ -1,0 +1,141 @@
+// MainHierarchyState.swift
+// RunBot
+
+import Observation
+import RunBotCore
+
+// MARK: - MainHierarchyState
+//
+// Process-lifetime UI state for the hierarchy displayed by `PanelMainView`.
+//
+// PROBLEM:
+// `RootPanelView` conditionally renders one route. Navigating to Settings or
+// Step Log removes `PanelMainView` from the SwiftUI hierarchy. Returning
+// constructs a fresh instance, destroying child `@State` in `ActionRowView`
+// and `InlineJobRowsView`.
+//
+// SOLUTION:
+// Hoist all user-controlled expansion state into this process-lifetime object
+// owned by `AppState`. Views read and write through computed properties;
+// `@State` is removed from row views for the hoisted fields.
+//
+// OWNERSHIP:
+// - Owned by `AppState` (one instance per process).
+// - Never recreated on route changes.
+// - Never reset in `navigateBack()` or panel hide/show callbacks.
+// - Never persisted to `UserDefaults`; resets on process termination.
+//
+// KEYING:
+// All entries are keyed by `WorkflowActionGroup.ID` (stable across polls).
+// Never key by row offset, visible index, title, SHA, or array order.
+//
+// PRUNING:
+// Call `retainGroups(_:)` whenever the set of current action IDs changes.
+// This prevents unbounded stale entries from accumulating.
+
+/// Process-lifetime UI state for the hierarchy displayed by `PanelMainView`.
+///
+/// Preserves workflow row expansion, nested job expansion, and visible-row
+/// count across route navigation (Settings ↔ Main, Step Log ↔ Main) and
+/// panel hide/unhide.
+@MainActor
+@Observable
+final class MainHierarchyState {
+
+    // MARK: - WorkflowExpansion
+
+    /// Tri-state expansion of a workflow row.
+    ///
+    /// Using a typed enum (rather than `Bool?`) lets the store distinguish
+    /// between "no entry yet" (absent key) and an explicit `.collapsed` set
+    /// by user action. This preserves automatic initial-expansion policy for
+    /// new rows while honouring user collapse intent on re-navigation.
+    enum WorkflowExpansion: Equatable {
+        /// User collapsed, or initial state for a non-in-progress workflow.
+        case collapsed  // nil  — user collapsed, or initial state for non-inProgress
+        /// In-progress workflow showing only running jobs.
+        case partial    // false — in-progress partial view
+        /// All jobs visible; set by explicit user tap.
+        case full       // true  — fully expanded by user tap
+
+        /// The `Bool?` representation used by `ActionRowView` / `RowTapModifier`.
+        var value: Bool? {
+            switch self {
+            case .collapsed: nil
+            case .partial:   false
+            case .full:      true
+            }
+        }
+
+        /// Converts from the existing tri-state `Bool?` row representation.
+        init(_ value: Bool?) {
+            switch value {
+            case nil:   self = .collapsed
+            case false: self = .partial
+            case true:  self = .full
+            }
+        }
+    }
+
+    // MARK: - Stored state
+
+    /// Per-workflow expansion state.
+    ///
+    /// An absent key means the row has never been visited; it may receive
+    /// automatic initial-expansion policy. An explicit `.collapsed` value
+    /// represents deliberate user intent and must survive navigation.
+    private(set) var workflowExpansions: [WorkflowActionGroup.ID: WorkflowExpansion] = [:]
+
+    /// Per-workflow set of expanded job IDs.
+    ///
+    /// Absent key is equivalent to an empty set. Stored as optional to avoid
+    /// retaining empty sets; `setJobs(_:for:)` clears the key on empty input.
+    private(set) var expandedJobIDs: [WorkflowActionGroup.ID: Set<Int>] = [:]
+
+    /// Current "load more" watermark; mirrors `PanelMainView`'s previous `@State`.
+    var visibleCount = 10
+
+    // MARK: - Workflow expansion accessors
+
+    /// Returns the stored expansion state, or `nil` if the row is new.
+    ///
+    /// `nil` is intentionally distinct from `.collapsed`: absent entries may
+    /// receive the existing automatic initial-expansion policy, while an
+    /// explicit `.collapsed` represents user intent.
+    func expansion(for groupID: WorkflowActionGroup.ID) -> WorkflowExpansion? {
+        workflowExpansions[groupID]
+    }
+
+    /// Stores the expansion state for the given workflow group.
+    func setExpansion(_ expansion: WorkflowExpansion, for groupID: WorkflowActionGroup.ID) {
+        workflowExpansions[groupID] = expansion
+    }
+
+    // MARK: - Job expansion accessors
+
+    /// Returns the set of expanded job IDs for a workflow, or an empty set.
+    func jobs(for groupID: WorkflowActionGroup.ID) -> Set<Int> {
+        expandedJobIDs[groupID, default: []]
+    }
+
+    /// Stores expanded job IDs for a workflow; clears the entry when `jobIDs` is empty.
+    func setJobs(_ jobIDs: Set<Int>, for groupID: WorkflowActionGroup.ID) {
+        expandedJobIDs[groupID] = jobIDs.isEmpty ? nil : jobIDs
+    }
+
+    /// Removes all expanded job IDs for the given workflow group.
+    func clearJobs(for groupID: WorkflowActionGroup.ID) {
+        expandedJobIDs[groupID] = nil
+    }
+
+    // MARK: - Pruning
+
+    /// Removes state for groups that are no longer present in the current poll.
+    ///
+    /// Call this whenever the set of `WorkflowActionGroup.ID`s changes.
+    /// Reordering the same set of IDs must not affect stored state.
+    func retainGroups(_ validGroupIDs: Set<WorkflowActionGroup.ID>) {
+        workflowExpansions = workflowExpansions.filter { validGroupIDs.contains($0.key) }
+        expandedJobIDs = expandedJobIDs.filter { validGroupIDs.contains($0.key) }
+    }
+}

--- a/Sources/RunBot/App/MainHierarchyState.swift
+++ b/Sources/RunBot/App/MainHierarchyState.swift
@@ -92,6 +92,13 @@ final class MainHierarchyState {
     /// retaining empty sets; `setJobs(_:for:)` clears the key on empty input.
     private(set) var expandedJobIDs: [WorkflowActionGroup.ID: Set<Int>] = [:]
 
+    /// Last observed RBStatus per workflow group.
+    ///
+    /// Persisted alongside expansion so that status transitions that occur
+    /// while Main is unmounted can be reconciled on re-appearance.
+    /// An absent key means the group has never been observed.
+    private(set) var workflowStatuses: [WorkflowActionGroup.ID: RBStatus] = [:]
+
     /// Current "load more" watermark; mirrors `PanelMainView`'s previous `@State`.
     var visibleCount = 10
 
@@ -107,8 +114,18 @@ final class MainHierarchyState {
     }
 
     /// Stores the expansion state for the given workflow group.
+    ///
+    /// Automatically clears nested job IDs when collapsing or transitioning
+    /// from full to partial, so callers never need to manage that cleanup.
     func setExpansion(_ expansion: WorkflowExpansion, for groupID: WorkflowActionGroup.ID) {
+        let previous = workflowExpansions[groupID]
         workflowExpansions[groupID] = expansion
+        switch (previous, expansion) {
+        case (_, .collapsed), (.some(.full), .partial):
+            clearJobs(for: groupID)
+        default:
+            break
+        }
     }
 
     // MARK: - Job expansion accessors
@@ -128,6 +145,70 @@ final class MainHierarchyState {
         expandedJobIDs[groupID] = nil
     }
 
+    // MARK: - Status accessors
+
+    /// Returns the last observed RBStatus for the given group, or nil if unseen.
+    func status(for groupID: WorkflowActionGroup.ID) -> RBStatus? {
+        workflowStatuses[groupID]
+    }
+
+    /// Records the current status for the given group.
+    func setStatus(_ status: RBStatus, for groupID: WorkflowActionGroup.ID) {
+        workflowStatuses[groupID] = status
+    }
+
+    // MARK: - Status reconciliation
+
+    /// Reconciles expansion state for a workflow against its new status.
+    ///
+    /// Call this from both `onAppear` (to catch transitions while Main was
+    /// unmounted) and the live status `onChange` (for mounted transitions).
+    /// Pass `animated: true` only for live transitions; never animate on
+    /// appearance reconciliation.
+    ///
+    /// Policy (mirrors the previous `@State`-based behaviour exactly):
+    /// - First observation of `.inProgress` → `.partial` if no entry yet.
+    /// - First observation of any non-running status → `.collapsed` if no entry.
+    /// - `.collapsed` + enters `.inProgress` → `.partial` (auto-expand).
+    /// - `.inProgress` → `.success` / `.failed` → `.collapsed` (auto-collapse).
+    /// - Any other stored expansion is preserved (user intent wins).
+    @discardableResult
+    func reconcile(
+        status newStatus: RBStatus,
+        for groupID: WorkflowActionGroup.ID
+    ) -> Bool {
+        let previousStatus = workflowStatuses[groupID]
+        let currentExpansion = workflowExpansions[groupID]
+        var changed = false
+
+        if previousStatus == nil {
+            // First time this group is seen: apply automatic initial policy.
+            if currentExpansion == nil {
+                setExpansion(
+                    newStatus == .inProgress ? .partial : .collapsed,
+                    for: groupID
+                )
+                changed = true
+            }
+        } else {
+            // Group was seen before — handle status transitions.
+            if newStatus == .inProgress,
+               currentExpansion == .collapsed {
+                // Workflow re-entered in-progress: auto-expand to partial.
+                setExpansion(.partial, for: groupID)
+                changed = true
+            } else if previousStatus == .inProgress,
+                      newStatus == .success || newStatus == .failed {
+                // Workflow completed: auto-collapse.
+                setExpansion(.collapsed, for: groupID)
+                changed = true
+            }
+        }
+
+        workflowStatuses[groupID] = newStatus
+        return changed
+    }
+
     // MARK: - Pruning
 
     /// Removes state for groups that are no longer present in the current poll.
@@ -137,5 +218,6 @@ final class MainHierarchyState {
     func retainGroups(_ validGroupIDs: Set<WorkflowActionGroup.ID>) {
         workflowExpansions = workflowExpansions.filter { validGroupIDs.contains($0.key) }
         expandedJobIDs = expandedJobIDs.filter { validGroupIDs.contains($0.key) }
+        workflowStatuses = workflowStatuses.filter { validGroupIDs.contains($0.key) }
     }
 }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -172,11 +172,14 @@ struct ActionRowView: View {
     }
 
     /// Animates expansion transitions triggered by live status changes.
+    ///
+    /// `reconcile()` must be called *inside* the `withAnimation` closure so that
+    /// the `hierarchyState.workflowExpansions` mutation is captured by the
+    /// animation transaction. Calling it before and then wrapping an empty closure
+    /// leaves the state change outside the transaction — the expand/collapse snaps.
     private func handleStatusChange(_ newStatus: RBStatus) {
-        let animation: Animation = .easeInOut(duration: 0.15)
-        let changed = hierarchyState.reconcile(status: newStatus, for: group.id)
-        if changed {
-            withAnimation(animation) {}
+        withAnimation(.easeInOut(duration: 0.15)) {
+            hierarchyState.reconcile(status: newStatus, for: group.id)
         }
         previousStatus = newStatus
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -154,40 +154,29 @@ struct ActionRowView: View {
         .allowsHitTesting(false)
     }
 
-    /// Sets the initial expand state based on the row's status at appear time.
-    /// Only applies the automatic default when the row has never been visited.
-    /// An existing entry (even .collapsed) represents user intent or a prior
-    /// navigation; do not overwrite it on re-mount after route change.
+    /// Reconciles expansion on appear, catching status transitions that
+    /// occurred while Main was unmounted, then seeds `previousStatus`.
+    ///
+    /// Does not animate: appearance reconciliation is not a live transition.
     private func applyInitialExpandState() {
         let status = rowStatus
+        hierarchyState.reconcile(status: status, for: group.id)
         previousStatus = status
-        if hierarchyState.expansion(for: group.id) == nil {
-            setExpandState((status == .inProgress) ? false : nil)
-        }
     }
 
-    /// Routes all expandState mutations through hierarchyState and handles
-    /// job-state cleanup on collapse/partial transitions.
+    /// Routes all user-driven expandState mutations through hierarchyState.
+    /// Job-state cleanup is owned by `MainHierarchyState.setExpansion`.
     private func setExpandState(_ newValue: Bool?) {
-        let oldExpansion = hierarchyState.expansion(for: group.id)
         let newExpansion = MainHierarchyState.WorkflowExpansion(newValue)
         hierarchyState.setExpansion(newExpansion, for: group.id)
-        switch (oldExpansion, newExpansion) {
-        case (_, .collapsed), (.some(.full), .partial):
-            hierarchyState.clearJobs(for: group.id)
-        default:
-            break
-        }
     }
 
-    /// Animates expand state transitions when the row status changes.
+    /// Animates expansion transitions triggered by live status changes.
     private func handleStatusChange(_ newStatus: RBStatus) {
         let animation: Animation = .easeInOut(duration: 0.15)
-        if newStatus == .inProgress && expandState == nil {
-            withAnimation(animation) { setExpandState(false) }
-        }
-        if previousStatus == .inProgress && (newStatus == .success || newStatus == .failed) {
-            withAnimation(animation) { setExpandState(nil) }
+        let changed = hierarchyState.reconcile(status: newStatus, for: group.id)
+        if changed {
+            withAnimation(animation) {}
         }
         previousStatus = newStatus
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -19,8 +19,13 @@ struct ActionRowView: View {
     let tick: Int
     /// Called when the user taps a step inside the expanded inline job rows.
     let onStepTap: (ActiveJob, GitHubStep) -> Void
-    /// Drives the inline expand/collapse state: `nil` = collapsed, `false` = partially expanded, `true` = fully expanded.
-    @State private var expandState: Bool?
+    /// Process-lifetime hierarchy state; owns expansion and nested-job state.
+    let hierarchyState: MainHierarchyState
+    /// Drives the inline expand/collapse state via hierarchyState.
+    /// nil = collapsed, false = partially expanded, true = fully expanded.
+    private var expandState: Bool? {
+        hierarchyState.expansion(for: group.id)?.value
+    }
     /// Tracks the previous row status to detect in-progress → done transitions.
     @State private var previousStatus: RBStatus?
 
@@ -42,7 +47,14 @@ struct ActionRowView: View {
                 rowContent
             }
             if let fullExpand = expandState {
-                InlineJobRowsView(group: group, tick: tick, fullExpand: fullExpand, onStepTap: onStepTap)
+                InlineJobRowsView(
+                    group: group,
+                    tick: tick,
+                    fullExpand: fullExpand,
+                    onStepTap: onStepTap,
+                    groupID: group.id,
+                    hierarchyState: hierarchyState
+                )
             }
         }
         .frame(maxWidth: .infinity)
@@ -68,7 +80,14 @@ struct ActionRowView: View {
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .workflowContextMenu(group: group)
-        .modifier(RowTapModifier(jobs: group.jobs, expandState: $expandState, rowStatus: rowStatus))
+        .modifier(RowTapModifier(
+            jobs: group.jobs,
+            expandState: Binding(
+                get: { expandState },
+                set: { setExpandState($0) }
+            ),
+            rowStatus: rowStatus
+        ))
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.xxs)
         .onAppear {
@@ -136,20 +155,39 @@ struct ActionRowView: View {
     }
 
     /// Sets the initial expand state based on the row's status at appear time.
+    /// Only applies the automatic default when the row has never been visited.
+    /// An existing entry (even .collapsed) represents user intent or a prior
+    /// navigation; do not overwrite it on re-mount after route change.
     private func applyInitialExpandState() {
         let status = rowStatus
         previousStatus = status
-        expandState = (status == .inProgress) ? false : nil
+        if hierarchyState.expansion(for: group.id) == nil {
+            setExpandState((status == .inProgress) ? false : nil)
+        }
+    }
+
+    /// Routes all expandState mutations through hierarchyState and handles
+    /// job-state cleanup on collapse/partial transitions.
+    private func setExpandState(_ newValue: Bool?) {
+        let oldExpansion = hierarchyState.expansion(for: group.id)
+        let newExpansion = MainHierarchyState.WorkflowExpansion(newValue)
+        hierarchyState.setExpansion(newExpansion, for: group.id)
+        switch (oldExpansion, newExpansion) {
+        case (_, .collapsed), (.some(.full), .partial):
+            hierarchyState.clearJobs(for: group.id)
+        default:
+            break
+        }
     }
 
     /// Animates expand state transitions when the row status changes.
     private func handleStatusChange(_ newStatus: RBStatus) {
         let animation: Animation = .easeInOut(duration: 0.15)
         if newStatus == .inProgress && expandState == nil {
-            withAnimation(animation) { expandState = false }
+            withAnimation(animation) { setExpandState(false) }
         }
         if previousStatus == .inProgress && (newStatus == .success || newStatus == .failed) {
-            withAnimation(animation) { expandState = nil }
+            withAnimation(animation) { setExpandState(nil) }
         }
         previousStatus = newStatus
     }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -495,8 +495,15 @@ struct InlineJobRowsView: View {
     }
     /// Tracks whether the panel popover is currently visible.
     @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
+    /// Stable group ID used to key hierarchy state lookups.
+    let groupID: WorkflowActionGroup.ID
+    /// Process-lifetime hierarchy state; owns job expansion per workflow.
+    let hierarchyState: MainHierarchyState
     /// The set of job IDs whose step lists are currently expanded.
-    @State private var expandedJobIDs: Set<Int> = []
+    /// Backed by hierarchyState so it survives route navigation.
+    private var expandedJobIDs: Set<Int> {
+        hierarchyState.jobs(for: groupID)
+    }
     /// A stable snapshot of `tick` captured at view evaluation time.
     ///
     /// Embedding `tick` in each `JobRowCard`'s SwiftUI identity string forces
@@ -527,7 +534,11 @@ struct InlineJobRowsView: View {
                             isLast: index == jobs.count - 1,
                             group: group,
                             isExpanded: expandedJobIDs.contains(job.id),
-                            onToggle: { expandedJobIDs.toggle(job.id) },
+                            onToggle: {
+                                var ids = hierarchyState.jobs(for: groupID)
+                                ids.toggle(job.id)
+                                hierarchyState.setJobs(ids, for: groupID)
+                            },
                             onStepTap: { step in onStepTap(job, step) }
                         )
                         // job.id alone would be stable enough for diffing, but tick
@@ -555,7 +566,7 @@ struct InlineJobRowsView: View {
         // Clearing expandedJobIDs here resets all job cards to their default closed
         // state, matching the expected "active row state" on collapse.
         .onChange(of: fullExpand) { _, newValue in
-            if !newValue { expandedJobIDs.removeAll() }
+            if !newValue { hierarchyState.clearJobs(for: groupID) }
         }
     }
 }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -565,8 +565,8 @@ struct InlineJobRowsView: View {
         // This means expandedJobIDs persists and steps appear expanded after collapse.
         // Clearing expandedJobIDs here resets all job cards to their default closed
         // state, matching the expected "active row state" on collapse.
-        .onChange(of: fullExpand) { _, newValue in
-            if !newValue { hierarchyState.clearJobs(for: groupID) }
-        }
+        // Job-state cleanup on full→partial is owned by
+        // MainHierarchyState.setExpansion; no duplicate clearJobs here.
+        .onChange(of: fullExpand) { _, _ in }
     }
 }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -95,7 +95,11 @@ struct PanelMainView: View {
     /// View model for CPU/GPU/memory stats displayed in the header.
     @State private var systemStats = SystemStatsViewModel()
     /// Number of workflow rows currently shown in the actions section.
-    @State private var visibleCount: Int = 10
+    /// Backed by `mainHierarchyState` so it survives Settings/StepLog navigation.
+    private var visibleCount: Int {
+        get { appState.mainHierarchyState.visibleCount }
+        nonmutating set { appState.mainHierarchyState.visibleCount = newValue }
+    }
     /// Increments every second to drive relative-time label refreshes without re-polling.
     @State private var displayTick: Int = 0
     /// Structured task driving the 1-second `displayTick` loop; managed by `startDisplayTickTimer()`.
@@ -276,7 +280,13 @@ Task { await localRunnerStore.refresh() }
             if newActions.count < oldActions.count { visibleCount = 10 }
             panelControllerHandle.remeasure()
         }
-        .onChange(of: appState.runnerState.runners) { _, newRunners in
+        .onChange(
+            of: appState.runnerState.actions.map(\.id),
+            initial: true
+        ) { _, groupIDs in
+            appState.mainHierarchyState.retainGroups(Set(groupIDs))
+        }
+                .onChange(of: appState.runnerState.runners) { _, newRunners in
             // Re-trigger enrichment so local.isBusy is stamped in lock-step with
             // every new GitHub runners poll. The isScanning guard in
             // LocalRunnerStore.performRefresh() prevents concurrent cycles.
@@ -344,7 +354,12 @@ Task { await localRunnerStore.refresh() }
             } else {
                 let visible = Array(appState.runnerState.actions.prefix(visibleCount))
                 ForEach(visible) { group in
-                    ActionRowView(group: group, tick: displayTick, onStepTap: onStepTap)
+                    ActionRowView(
+                        group: group,
+                        tick: displayTick,
+                        onStepTap: onStepTap,
+                        hierarchyState: appState.mainHierarchyState
+                    )
                 }
                 loadMoreButton
             }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -286,7 +286,7 @@ Task { await localRunnerStore.refresh() }
         ) { _, groupIDs in
             appState.mainHierarchyState.retainGroups(Set(groupIDs))
         }
-                .onChange(of: appState.runnerState.runners) { _, newRunners in
+        .onChange(of: appState.runnerState.runners) { _, newRunners in
             // Re-trigger enrichment so local.isBusy is stamped in lock-step with
             // every new GitHub runners poll. The isScanning guard in
             // LocalRunnerStore.performRefresh() prevents concurrent cycles.

--- a/Tests/RunBotTests/State/MainHierarchyStateTests.swift
+++ b/Tests/RunBotTests/State/MainHierarchyStateTests.swift
@@ -4,48 +4,95 @@
 import Testing
 @testable import RunBot
 
+/// Tests for ``MainHierarchyState``.
+///
+/// Covers expansion storage, job-state cleanup invariants owned by
+/// `setExpansion`, status reconciliation (both first-observation and
+/// transition), pruning, and visible-count persistence.
 @MainActor
 struct MainHierarchyStateTests {
 
-    // 1. New group has no stored entry
-    @Test func newGroupHasNoEntry() {
+    // MARK: - Expansion storage
+
+    /// Verifies that a new workflow group has no stored expansion entry.
+    @Test
+    func newGroupHasNoEntry() {
         let state = MainHierarchyState()
         #expect(state.expansion(for: "group-1") == nil)
     }
 
-    // 2. Explicit .collapsed is distinct from no entry
-    @Test func collapsedIsDistinctFromAbsent() {
+    /// Verifies that an explicit `.collapsed` entry is distinct from no entry.
+    @Test
+    func collapsedIsDistinctFromAbsent() {
         let state = MainHierarchyState()
         state.setExpansion(.collapsed, for: "group-1")
         #expect(state.expansion(for: "group-1") == .collapsed)
         #expect(state.expansion(for: "group-2") == nil)
     }
 
-    // 3. .partial survives repeated reads
-    @Test func partialSurvivesRepeatedReads() {
+    /// Verifies that `.partial` survives repeated reads.
+    @Test
+    func partialSurvivesRepeatedReads() {
         let state = MainHierarchyState()
         state.setExpansion(.partial, for: "g")
         #expect(state.expansion(for: "g") == .partial)
         #expect(state.expansion(for: "g") == .partial)
     }
 
-    // 4. .full survives repeated reads
-    @Test func fullSurvivesRepeatedReads() {
+    /// Verifies that `.full` survives repeated reads.
+    @Test
+    func fullSurvivesRepeatedReads() {
         let state = MainHierarchyState()
         state.setExpansion(.full, for: "g")
         #expect(state.expansion(for: "g") == .full)
         #expect(state.expansion(for: "g") == .full)
     }
 
-    // 5. Job IDs stored per workflow group
-    @Test func jobIDsStoredPerGroup() {
+    // MARK: - Job-state cleanup invariants (owned by setExpansion)
+
+    /// Verifies that `setExpansion(.partial)` from `.full` clears nested jobs.
+    ///
+    /// Tests the production contract of `setExpansion`; callers must not
+    /// need to manage this cleanup themselves.
+    @Test
+    func fullToPartialClearsJobs() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "wf-a")
+        state.setJobs([1, 2], for: "wf-a")
+
+        state.setExpansion(.partial, for: "wf-a")
+
+        #expect(state.jobs(for: "wf-a").isEmpty)
+    }
+
+    /// Verifies that `setExpansion(.collapsed)` clears nested jobs.
+    ///
+    /// Tests the production contract of `setExpansion`; callers must not
+    /// need to call `clearJobs` separately.
+    @Test
+    func explicitCollapseClearsJobs() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "wf-a")
+        state.setJobs([1, 2], for: "wf-a")
+
+        state.setExpansion(.collapsed, for: "wf-a")
+
+        #expect(state.jobs(for: "wf-a").isEmpty)
+    }
+
+    // MARK: - Job expansion accessors
+
+    /// Verifies that job IDs are stored independently per workflow group.
+    @Test
+    func jobIDsStoredPerGroup() {
         let state = MainHierarchyState()
         state.setJobs([1, 2, 3], for: "wf-a")
         #expect(state.jobs(for: "wf-a") == [1, 2, 3])
     }
 
-    // 6. Two groups do not share nested job state
-    @Test func groupsDoNotShareJobState() {
+    /// Verifies that two workflow groups do not share nested job state.
+    @Test
+    func groupsDoNotShareJobState() {
         let state = MainHierarchyState()
         state.setJobs([1], for: "wf-a")
         state.setJobs([2], for: "wf-b")
@@ -53,40 +100,159 @@ struct MainHierarchyStateTests {
         #expect(state.jobs(for: "wf-b") == [2])
     }
 
-    // 7. Empty job sets remove their dictionary entry (returns empty set)
-    @Test func emptyJobSetIsEmpty() {
+    /// Verifies that setting an empty job set returns an empty set on read.
+    @Test
+    func emptyJobSetIsEmpty() {
         let state = MainHierarchyState()
         state.setJobs([1], for: "wf-a")
         state.setJobs([], for: "wf-a")
         #expect(state.jobs(for: "wf-a").isEmpty)
     }
 
-    // 8. retainGroups keeps current groups
-    @Test func retainGroupsKeepsCurrent() {
+    // MARK: - Status reconciliation: first observation
+
+    /// Verifies that the first observation of `.inProgress` initializes `.partial`.
+    @Test
+    func firstInProgressInitializesPartial() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .inProgress, for: "wf-a")
+        #expect(state.expansion(for: "wf-a") == .partial)
+    }
+
+    /// Verifies that the first observation of a terminal status initializes `.collapsed`.
+    @Test
+    func firstSuccessInitializesCollapsed() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .success, for: "wf-a")
+        #expect(state.expansion(for: "wf-a") == .collapsed)
+    }
+
+    /// Verifies that the first observation of `.queued` initializes `.collapsed`.
+    @Test
+    func firstQueuedInitializesCollapsed() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .queued, for: "wf-a")
+        #expect(state.expansion(for: "wf-a") == .collapsed)
+    }
+
+    // MARK: - Status reconciliation: transitions while unmounted
+
+    /// Verifies that `.inProgress` → `.success` while Main is unmounted collapses expansion.
+    @Test
+    func inProgressToSuccessWhileUnmountedCollapses() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .inProgress, for: "wf-a") // partial
+        state.setExpansion(.partial, for: "wf-a")
+
+        // Simulate Main unmount: no view is observing status changes.
+        // On remount, ActionRowView calls reconcile with the current status.
+        state.reconcile(status: .success, for: "wf-a")
+
+        #expect(state.expansion(for: "wf-a") == .collapsed)
+    }
+
+    /// Verifies that `.inProgress` → `.failed` while Main is unmounted collapses expansion.
+    @Test
+    func inProgressToFailedWhileUnmountedCollapses() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .inProgress, for: "wf-a")
+
+        state.reconcile(status: .failed, for: "wf-a")
+
+        #expect(state.expansion(for: "wf-a") == .collapsed)
+    }
+
+    /// Verifies that `.collapsed` → `.inProgress` while Main is unmounted auto-expands to partial.
+    @Test
+    func queuedCollapsedToInProgressWhileUnmountedExpandsToPartial() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .queued, for: "wf-a") // .collapsed
+
+        state.reconcile(status: .inProgress, for: "wf-a")
+
+        #expect(state.expansion(for: "wf-a") == .partial)
+    }
+
+    /// Verifies that a completed workflow that was explicitly expanded remains `.full`
+    /// when no status transition occurred while Main was away.
+    @Test
+    func completedFullWithNoTransitionRemainsFullOnRemount() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .success, for: "wf-a") // .collapsed
+        state.setExpansion(.full, for: "wf-a")         // user tapped expand
+
+        // Remount: status is still .success — no transition.
+        state.reconcile(status: .success, for: "wf-a")
+
+        #expect(state.expansion(for: "wf-a") == .full)
+    }
+
+    /// Verifies that a terminal → success transition (e.g. re-run) while unmounted
+    /// does not collapse an explicitly expanded row (no inProgress previous).
+    @Test
+    func terminalToSuccessWithNoInProgressDoesNotCollapse() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .failed, for: "wf-a")  // .collapsed
+        state.setExpansion(.full, for: "wf-a")          // user expanded
+
+        state.reconcile(status: .success, for: "wf-a")
+
+        #expect(state.expansion(for: "wf-a") == .full)
+    }
+
+    /// Verifies that a terminal transition clears nested job IDs.
+    @Test
+    func inProgressToSuccessClearsNestedJobs() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .inProgress, for: "wf-a")
+        state.setJobs([1, 2], for: "wf-a")
+
+        state.reconcile(status: .success, for: "wf-a")
+
+        #expect(state.jobs(for: "wf-a").isEmpty)
+    }
+
+    /// Verifies that status entries are pruned when their workflow group is removed.
+    @Test
+    func retainGroupsPrunesStaleStatuses() {
+        let state = MainHierarchyState()
+        state.reconcile(status: .success, for: "wf-stale")
+        state.retainGroups([])
+        #expect(state.status(for: "wf-stale") == nil)
+    }
+
+    // MARK: - Pruning
+
+    /// Verifies that `retainGroups` keeps current groups.
+    @Test
+    func retainGroupsKeepsCurrent() {
         let state = MainHierarchyState()
         state.setExpansion(.full, for: "wf-a")
         state.retainGroups(["wf-a"])
         #expect(state.expansion(for: "wf-a") == .full)
     }
 
-    // 9. retainGroups removes obsolete workflow expansion
-    @Test func retainGroupsRemovesObsoleteExpansion() {
+    /// Verifies that `retainGroups` removes obsolete workflow expansion.
+    @Test
+    func retainGroupsRemovesObsoleteExpansion() {
         let state = MainHierarchyState()
         state.setExpansion(.full, for: "wf-stale")
         state.retainGroups([])
         #expect(state.expansion(for: "wf-stale") == nil)
     }
 
-    // 10. retainGroups removes obsolete nested job state
-    @Test func retainGroupsRemovesObsoleteJobs() {
+    /// Verifies that `retainGroups` removes obsolete nested job state.
+    @Test
+    func retainGroupsRemovesObsoleteJobs() {
         let state = MainHierarchyState()
         state.setJobs([1, 2], for: "wf-stale")
         state.retainGroups([])
         #expect(state.jobs(for: "wf-stale").isEmpty)
     }
 
-    // 11. Reordering same group IDs does not affect stored state
-    @Test func reorderingDoesNotAffectState() {
+    /// Verifies that reordering the same group IDs does not affect stored state.
+    @Test
+    func reorderingDoesNotAffectState() {
         let state = MainHierarchyState()
         state.setExpansion(.full, for: "wf-a")
         state.setExpansion(.partial, for: "wf-b")
@@ -95,37 +261,18 @@ struct MainHierarchyStateTests {
         #expect(state.expansion(for: "wf-b") == .partial)
     }
 
-    // 12. Transitioning full -> partial clears nested jobs
-    @Test func fullToPartialClearsJobs() {
-        let state = MainHierarchyState()
-        state.setExpansion(.full, for: "wf-a")
-        state.setJobs([1, 2], for: "wf-a")
-        let oldExpansion = state.expansion(for: "wf-a")
-        let newExpansion = MainHierarchyState.WorkflowExpansion(false) // .partial
-        state.setExpansion(newExpansion, for: "wf-a")
-        if case (.some(.full), .partial) = (oldExpansion, newExpansion) {
-            state.clearJobs(for: "wf-a")
-        }
-        #expect(state.jobs(for: "wf-a").isEmpty)
-    }
+    // MARK: - Visible count
 
-    // 13. Explicit collapse clears nested jobs
-    @Test func explicitCollapseClearsJobs() {
-        let state = MainHierarchyState()
-        state.setJobs([1, 2], for: "wf-a")
-        state.setExpansion(.collapsed, for: "wf-a")
-        state.clearJobs(for: "wf-a")
-        #expect(state.jobs(for: "wf-a").isEmpty)
-    }
-
-    // 14. visibleCount defaults to 10
-    @Test func visibleCountDefaults() {
+    /// Verifies that `visibleCount` defaults to 10.
+    @Test
+    func visibleCountDefaults() {
         let state = MainHierarchyState()
         #expect(state.visibleCount == 10)
     }
 
-    // 15. visibleCount survives mutation
-    @Test func visibleCountSurvivesMutation() {
+    /// Verifies that `visibleCount` survives mutation.
+    @Test
+    func visibleCountSurvivesMutation() {
         let state = MainHierarchyState()
         state.visibleCount = 25
         #expect(state.visibleCount == 25)

--- a/Tests/RunBotTests/State/MainHierarchyStateTests.swift
+++ b/Tests/RunBotTests/State/MainHierarchyStateTests.swift
@@ -1,0 +1,133 @@
+// MainHierarchyStateTests.swift
+// RunBotTests
+
+import Testing
+@testable import RunBot
+
+@MainActor
+struct MainHierarchyStateTests {
+
+    // 1. New group has no stored entry
+    @Test func newGroupHasNoEntry() {
+        let state = MainHierarchyState()
+        #expect(state.expansion(for: "group-1") == nil)
+    }
+
+    // 2. Explicit .collapsed is distinct from no entry
+    @Test func collapsedIsDistinctFromAbsent() {
+        let state = MainHierarchyState()
+        state.setExpansion(.collapsed, for: "group-1")
+        #expect(state.expansion(for: "group-1") == .collapsed)
+        #expect(state.expansion(for: "group-2") == nil)
+    }
+
+    // 3. .partial survives repeated reads
+    @Test func partialSurvivesRepeatedReads() {
+        let state = MainHierarchyState()
+        state.setExpansion(.partial, for: "g")
+        #expect(state.expansion(for: "g") == .partial)
+        #expect(state.expansion(for: "g") == .partial)
+    }
+
+    // 4. .full survives repeated reads
+    @Test func fullSurvivesRepeatedReads() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "g")
+        #expect(state.expansion(for: "g") == .full)
+        #expect(state.expansion(for: "g") == .full)
+    }
+
+    // 5. Job IDs stored per workflow group
+    @Test func jobIDsStoredPerGroup() {
+        let state = MainHierarchyState()
+        state.setJobs([1, 2, 3], for: "wf-a")
+        #expect(state.jobs(for: "wf-a") == [1, 2, 3])
+    }
+
+    // 6. Two groups do not share nested job state
+    @Test func groupsDoNotShareJobState() {
+        let state = MainHierarchyState()
+        state.setJobs([1], for: "wf-a")
+        state.setJobs([2], for: "wf-b")
+        #expect(state.jobs(for: "wf-a") == [1])
+        #expect(state.jobs(for: "wf-b") == [2])
+    }
+
+    // 7. Empty job sets remove their dictionary entry (returns empty set)
+    @Test func emptyJobSetIsEmpty() {
+        let state = MainHierarchyState()
+        state.setJobs([1], for: "wf-a")
+        state.setJobs([], for: "wf-a")
+        #expect(state.jobs(for: "wf-a").isEmpty)
+    }
+
+    // 8. retainGroups keeps current groups
+    @Test func retainGroupsKeepsCurrent() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "wf-a")
+        state.retainGroups(["wf-a"])
+        #expect(state.expansion(for: "wf-a") == .full)
+    }
+
+    // 9. retainGroups removes obsolete workflow expansion
+    @Test func retainGroupsRemovesObsoleteExpansion() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "wf-stale")
+        state.retainGroups([])
+        #expect(state.expansion(for: "wf-stale") == nil)
+    }
+
+    // 10. retainGroups removes obsolete nested job state
+    @Test func retainGroupsRemovesObsoleteJobs() {
+        let state = MainHierarchyState()
+        state.setJobs([1, 2], for: "wf-stale")
+        state.retainGroups([])
+        #expect(state.jobs(for: "wf-stale").isEmpty)
+    }
+
+    // 11. Reordering same group IDs does not affect stored state
+    @Test func reorderingDoesNotAffectState() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "wf-a")
+        state.setExpansion(.partial, for: "wf-b")
+        state.retainGroups(["wf-b", "wf-a"])
+        #expect(state.expansion(for: "wf-a") == .full)
+        #expect(state.expansion(for: "wf-b") == .partial)
+    }
+
+    // 12. Transitioning full -> partial clears nested jobs
+    @Test func fullToPartialClearsJobs() {
+        let state = MainHierarchyState()
+        state.setExpansion(.full, for: "wf-a")
+        state.setJobs([1, 2], for: "wf-a")
+        let oldExpansion = state.expansion(for: "wf-a")
+        let newExpansion = MainHierarchyState.WorkflowExpansion(false) // .partial
+        state.setExpansion(newExpansion, for: "wf-a")
+        if case (.some(.full), .partial) = (oldExpansion, newExpansion) {
+            state.clearJobs(for: "wf-a")
+        }
+        #expect(state.jobs(for: "wf-a").isEmpty)
+    }
+
+    // 13. Explicit collapse clears nested jobs
+    @Test func explicitCollapseClearsJobs() {
+        let state = MainHierarchyState()
+        state.setJobs([1, 2], for: "wf-a")
+        state.setExpansion(.collapsed, for: "wf-a")
+        state.clearJobs(for: "wf-a")
+        #expect(state.jobs(for: "wf-a").isEmpty)
+    }
+
+    // 14. visibleCount defaults to 10
+    @Test func visibleCountDefaults() {
+        let state = MainHierarchyState()
+        #expect(state.visibleCount == 10)
+    }
+
+    // 15. visibleCount survives mutation
+    @Test func visibleCountSurvivesMutation() {
+        let state = MainHierarchyState()
+        state.visibleCount = 25
+        #expect(state.visibleCount == 25)
+    }
+}


### PR DESCRIPTION
Fixes #2727.

Hoists workflow and nested-job expansion state out of transient SwiftUI row views into process-lifetime `MainHierarchyState` owned by `AppState`.

`RootPanelView` removes `PanelMainView` while Settings or Step Log is active, which previously destroyed `ActionRowView` and `InlineJobRowsView` `@State`. Returning to Main now restores workflow expansion, nested job expansion, and visible row count by stable workflow identity.

Explicit collapse behavior and existing status-transition rules remain unchanged. Stale state is pruned when workflow groups disappear.

See also: #2747 (design proposal)

## Summary by Sourcery

Preserve Main panel workflow and nested job expansion state across route navigation by hoisting hierarchy-related UI state into a process-lifetime store owned by AppState and wiring Main views to read/write from it.

Enhancements:
- Introduce a MainHierarchyState store to manage per-workflow expansion, nested job expansion, and visible row count keyed by stable workflow IDs.
- Update ActionRowView and InlineJobRowsView to derive and persist expansion state and expanded job IDs via MainHierarchyState instead of transient @State, including cleanup on collapse or partial transitions.
- Back visible workflow row count in PanelMainView with MainHierarchyState and prune stale hierarchy entries when the set of workflow groups changes.

Build:
- Register the new RunBotTests test target in Package.swift with appropriate Swift settings.

Tests:
- Add a RunBotTests test target and unit tests validating MainHierarchyState behavior for expansion state, nested job state, pruning, and visibleCount persistence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Main workflow and nested-job expansion and visible row count across route changes and panel hide/show. Previously, navigating to Settings or Step Log unmounted Main and reset row state; returning now restores expansion and applies missed status transitions, with live transitions animating correctly.

- Introduces `MainHierarchyState` in `AppState`: per-workflow tri-state expansion, expanded job IDs, last-seen status, and `visibleCount`; keyed by `WorkflowActionGroup.ID`, not persisted, and not cleared by navigateBack/closePanel. Automatic initial expansion applies only when no entry exists.
- Reconciles expansion with status: first-seen `.inProgress` → partial; first-seen non-running → collapsed; collapsed → enters `.inProgress` auto-expands to partial; `.inProgress` → terminal auto-collapses. Runs on appear (no animation) and on live changes (animated).
- Ensures animations run: calls `reconcile()` inside `withAnimation` for live status transitions to avoid snapping.
- Centralizes job cleanup in `MainHierarchyState.setExpansion`: collapsing or full → partial clears nested job IDs; removes duplicate cleanup in views.
- Wires views to the store: `ActionRowView` reads/writes expansion and reconciles on appear/status change; `InlineJobRowsView` persists expanded job IDs and drops clear-on-partial; `PanelMainView` backs `visibleCount` with the store and prunes stale entries via `retainGroups` when action IDs change.
- Adds `RunBotTests` with unit tests for expansion storage, job-state cleanup, status reconciliation, pruning, and `visibleCount`.

<sup>Written for commit 24689e8af216866919ade7357f83d309d2a9f419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved workflow and nested job expansion states when navigating between routes or opening and closing panels.
  * Maintained visible workflow counts and expansion preferences across view updates.
  * Improved expansion behavior when workflows transition between expanded, partially expanded, and collapsed states.

* **Tests**
  * Added coverage for hierarchy state persistence, workflow isolation, job expansion, reordering, cleanup, and visible-row counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->