### PR TITLE
feat: wire app sidebar navigation

### DIFF
--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -3,14 +3,28 @@
 
 import SwiftUI
 
-/// Neutral detail placeholder for the migration shell.
-/// Replaced by feature-specific views in later PRs.
+/// Detail column router. Switches on the current sidebar selection.
+/// The `nil` case is defensive; Workflows is always selected on launch.
 struct AppDetailView: View {
-    /// The placeholder content.
+    /// The currently selected sidebar section.
+    let selection: AppSection?
+
+    /// Routes to the corresponding feature-root view.
     var body: some View {
-        ContentUnavailableView(
-            "Select an item",
-            systemImage: "sidebar.left"
-        )
+        switch selection {
+        case .workflows:
+            MigrationWorkflowView()
+        case .localRunners:
+            MigrationRunnerView()
+        case .scopes:
+            MigrationScopeView()
+        case .settings:
+            MigrationSettingsView()
+        case nil:
+            ContentUnavailableView(
+                "Select an item",
+                systemImage: "sidebar.left"
+            )
+        }
     }
 }

--- a/Sources/RunBot/migration/AppShell/AppSection.swift
+++ b/Sources/RunBot/migration/AppShell/AppSection.swift
@@ -1,0 +1,40 @@
+// AppSection.swift
+// RunBot
+
+import SwiftUI
+
+/// Top-level sidebar route model.
+/// Raw string value prepares for `@SceneStorage` persistence in a later step.
+enum AppSection: String, CaseIterable, Identifiable {
+    /// The workflows feature destination.
+    case workflows
+    /// The local runners feature destination.
+    case localRunners
+    /// The scopes feature destination.
+    case scopes
+    /// The settings feature destination.
+    case settings
+
+    /// Stable identity for `List` and `NavigationSplitView` selection.
+    var id: Self { self }
+
+    /// Display title for the sidebar row.
+    var title: String {
+        switch self {
+        case .workflows: "Workflows"
+        case .localRunners: "Local runners"
+        case .scopes: "Scopes"
+        case .settings: "Settings"
+        }
+    }
+
+    /// SF Symbol name for the sidebar row icon.
+    var systemImage: String {
+        switch self {
+        case .workflows: "bolt.horizontal.circle"
+        case .localRunners: "desktopcomputer"
+        case .scopes: "scope"
+        case .settings: "gearshape"
+        }
+    }
+}

--- a/Sources/RunBot/migration/AppShell/AppShellView.swift
+++ b/Sources/RunBot/migration/AppShell/AppShellView.swift
@@ -4,19 +4,22 @@
 import SwiftUI
 
 /// Root two-column navigation shell.
-/// Intentionally static; sidebar routing is introduced separately.
+/// Owns the top-level sidebar selection; sidebar routing is wired here.
 struct AppShellView: View {
+    /// Currently selected sidebar section. Defaults to Workflows.
+    @State private var selection: AppSection? = .workflows
+
     /// The top-level split-view layout.
     var body: some View {
         NavigationSplitView {
-            AppSidebarView()
+            AppSidebarView(selection: $selection)
                 .navigationSplitViewColumnWidth(
                     min: 180,
                     ideal: 220,
                     max: 280
                 )
         } detail: {
-            AppDetailView()
+            AppDetailView(selection: selection)
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 720, minHeight: 480)

--- a/Sources/RunBot/migration/AppShell/AppSidebarView.swift
+++ b/Sources/RunBot/migration/AppShell/AppSidebarView.swift
@@ -3,14 +3,17 @@
 
 import SwiftUI
 
-/// Static sidebar column for the migration shell.
-/// Placeholder only — routing rows are added in PR 2.
+/// Sidebar column with selectable navigation rows.
+/// Status indicators and counts are added in later migration steps.
 struct AppSidebarView: View {
-    /// The sidebar list content.
+    /// Binding to the shell's current section selection.
+    @Binding var selection: AppSection?
+
+    /// The selectable section list.
     var body: some View {
-        List {
-            Text("RunBot")
-                .foregroundStyle(.secondary)
+        List(AppSection.allCases, selection: $selection) { section in
+            Label(section.title, systemImage: section.systemImage)
+                .tag(section)
         }
         .navigationTitle("RunBot")
     }

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerView.swift
@@ -1,0 +1,18 @@
+// MigrationRunnerView.swift
+// RunBot
+
+import SwiftUI
+
+/// Placeholder root view for the Local runners destination.
+/// Internal layout is introduced in a later migration step.
+struct MigrationRunnerView: View {
+    /// The placeholder content.
+    var body: some View {
+        ContentUnavailableView(
+            "Local runners",
+            systemImage: "desktopcomputer",
+            description: Text("Local runner management will be added in a later migration step.")
+        )
+        .navigationTitle("Local runners")
+    }
+}

--- a/Sources/RunBot/migration/Features/Scopes/MigrationScopeView.swift
+++ b/Sources/RunBot/migration/Features/Scopes/MigrationScopeView.swift
@@ -1,0 +1,18 @@
+// MigrationScopeView.swift
+// RunBot
+
+import SwiftUI
+
+/// Placeholder root view for the Scopes destination.
+/// Internal layout is introduced in a later migration step.
+struct MigrationScopeView: View {
+    /// The placeholder content.
+    var body: some View {
+        ContentUnavailableView(
+            "Scopes",
+            systemImage: "scope",
+            description: Text("Scope management will be added in a later migration step.")
+        )
+        .navigationTitle("Scopes")
+    }
+}

--- a/Sources/RunBot/migration/Features/Settings/MigrationSettingsView.swift
+++ b/Sources/RunBot/migration/Features/Settings/MigrationSettingsView.swift
@@ -1,0 +1,18 @@
+// MigrationSettingsView.swift
+// RunBot
+
+import SwiftUI
+
+/// Placeholder root view for the Settings destination.
+/// Internal layout is introduced in a later migration step.
+struct MigrationSettingsView: View {
+    /// The placeholder content.
+    var body: some View {
+        ContentUnavailableView(
+            "Settings",
+            systemImage: "gearshape",
+            description: Text("Settings controls will be added in a later migration step.")
+        )
+        .navigationTitle("Settings")
+    }
+}

--- a/Sources/RunBot/migration/Features/Workflows/MigrationWorkflowView.swift
+++ b/Sources/RunBot/migration/Features/Workflows/MigrationWorkflowView.swift
@@ -1,0 +1,18 @@
+// MigrationWorkflowView.swift
+// RunBot
+
+import SwiftUI
+
+/// Placeholder root view for the Workflows destination.
+/// Internal layout is introduced in a later migration step.
+struct MigrationWorkflowView: View {
+    /// The placeholder content.
+    var body: some View {
+        ContentUnavailableView(
+            "Workflows",
+            systemImage: "bolt.horizontal.circle",
+            description: Text("Workflow navigation will be added in the next migration step.")
+        )
+        .navigationTitle("Workflows")
+    }
+}


### PR DESCRIPTION
Part of #2793
Stacked on #2798

## What

Adds top-level sidebar navigation to the new SwiftUI app shell.

The sidebar now exposes Workflows, Local runners, Scopes, and Settings. Selecting an item switches the root detail view to the corresponding feature placeholder.

## Changes

- Add `AppSection` as the top-level sidebar route model.
- Store the current selection in `AppShellView`.
- Replace the static sidebar with four selectable rows.
- Route the detail column through `AppDetailView`.
- Add placeholder `MigrationWorkflowView`.
- Add placeholder `MigrationRunnerView`.
- Add placeholder `MigrationScopeView`.
- Add placeholder `MigrationSettingsView`.

> **Note on naming:** Feature-root views use a `Migration` prefix (`MigrationWorkflowView` etc.) to avoid a compile-time conflict with the existing legacy `SettingsView` in `Sources/RunBot/Views/`. The prefix will be dropped when the legacy views are removed in their respective migration steps.

## Out of scope

- Feature data and legacy store integration.
- Workflow/job/step/log columns.
- Runner and scope list/detail layouts.
- Settings controls.
- Sidebar status indicators and counts.
- Metrics.
- Window and selection restoration.

## Acceptance criteria

- [ ] Workflows is selected when the app launches.
- [ ] The sidebar displays Workflows, Local runners, Scopes, and Settings.
- [ ] Every sidebar row has a title and system image.
- [ ] Selecting each row displays its corresponding feature-root view.
- [ ] Selection works with mouse and keyboard navigation.
- [ ] Collapsing and reopening the sidebar preserves the in-memory selection.
- [ ] No feature data, stores, polling, or legacy views are initialized.
- [ ] All changes are contained under `Sources/RunBot/migration/`.
- [ ] `Package.swift`, `build.sh`, `project.yml`, and `main.swift` are unchanged.
- [ ] `swift build` passes ✅
- [ ] SwiftLint passes ✅
- [ ] `swift test` passes (CI).
- [ ] `build.sh` release build passes (CI).

## Summary by Sourcery

Introduce top-level sidebar navigation in the SwiftUI migration app shell and route the detail column to feature placeholder views based on the current selection.

New Features:
- Add AppSection enum as the top-level sidebar route model with titles and icons for Workflows, Local runners, Scopes, and Settings.
- Wire AppShellView to own and persist the current sidebar selection, defaulting to Workflows on launch.
- Make AppSidebarView a selectable list bound to the shared selection, exposing navigation rows for all top-level sections.
- Update AppDetailView to route the detail column to the corresponding feature-root view based on the selected AppSection.
- Add placeholder feature-root views for Workflows, Local runners, Scopes, and Settings in the migration namespace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the SwiftUI app shell to a selectable sidebar and detail router. Previously the sidebar was static with a neutral detail; now it lists Workflows, Local runners, Scopes, and Settings, and switches the detail to each feature’s placeholder. Workflows is selected on launch.

- Review notes
  - `AppSection` drives the sidebar and routing; it defines titles and SF Symbols for each top-level section.
  - `AppShellView` owns the selection and binds it to `AppSidebarView` and `AppDetailView`; selection is in-memory only.
  - Placeholder roots (`MigrationWorkflowView`, `MigrationRunnerView`, `MigrationScopeView`, `MigrationSettingsView`) are namespaced to avoid legacy view conflicts; no data or stores are initialized.
  - All changes are under Sources/RunBot/migration/; build scripts and project configuration are unchanged.

<sup>Written for commit b1d3c1cc4f056ba1b8a37cab4d14af39821252a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

