### PR TITLE
feat: migrate scope management

### DIFF
--- a/Sources/RunBot/Views/Settings/ScopeRowView.swift
+++ b/Sources/RunBot/Views/Settings/ScopeRowView.swift
@@ -1,0 +1,92 @@
+// ScopeRowView.swift
+// RunBot
+
+import RunBotCore
+import SwiftUI
+
+// MARK: - ScopeRowView
+
+/// Reusable scope row extracted from `ScopesView`.
+///
+/// Displays scope identity, enable/disable toggle, and delete button.
+/// Toggle and delete do not also fire `onSelect`.
+struct ScopeRowView: View {
+
+    // MARK: - Inputs
+
+    /// The scope entry to display.
+    let scope: ScopeEntry
+    /// Called when the row body is tapped (selection).
+    let onSelect: () -> Void
+    /// Called when the toggle is flipped with the new enabled state.
+    let onSetEnabled: (Bool) -> Void
+    /// Called when the delete button is tapped.
+    let onDelete: () -> Void
+
+    // MARK: - Body
+
+    /// The row layout.
+    var body: some View {
+        let isRepo = scope.scope.contains("/")
+        let displayName = scope.displayName ?? scope.scope
+        let hasAlias = scope.displayName != nil
+        return Button {
+            onSelect()
+        } label: {
+            HStack(spacing: 8) {
+                Text(isRepo ? "Repo" : "Org")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.rbSurfaceElevated))
+                    .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(displayName)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if hasAlias {
+                        Text(scope.scope)
+                            .font(.caption2)
+                            .foregroundColor(Color.rbTextTertiary)
+                            .lineLimit(1).truncationMode(.middle)
+                    }
+                }
+                Spacer()
+                Text(scope.isEnabled ? "Active" : "Paused")
+                    .font(.caption2)
+                    .foregroundColor(scope.isEnabled ? Color.rbSuccess : Color.rbTextTertiary)
+                Toggle("", isOn: Binding(
+                    get: { scope.isEnabled },
+                    set: { onSetEnabled($0) }
+                ))
+                .toggleStyle(.switch)
+                .tint(Color.rbSuccess)
+                .labelsHidden()
+                .help(scope.isEnabled ? "Pause monitoring" : "Resume monitoring")
+                .scaleEffect(0.8, anchor: .trailing)
+                .buttonStyle(.borderless)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextTertiary)
+                Button {
+                    onDelete()
+                } label: {
+                    Image(systemName: "minus.circle")
+                        .font(.caption2)
+                        .foregroundColor(Color.rbDanger)
+                }
+                .buttonStyle(.borderless)
+                .help("Remove scope")
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 5)
+        .settingsGlassCard(background: .rbGlassNeutralBackground, cornerRadius: RBRadius.small)
+        .padding(.horizontal, RBSpacing.xs)
+        .opacity(scope.isEnabled ? 1.0 : 0.5)
+    }
+}

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -209,102 +209,27 @@ struct ScopesView: View {
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         } else {
             VStack(spacing: RBSpacing.xs) {
-                ForEach(scopeStore.entries) { entry in scopeRow(entry) }
+                ForEach(scopeStore.entries) { entry in
+                    ScopeRowView(
+                        scope: entry,
+                        onSelect: {
+                            guard selectedScopeEntry == nil else { return }
+                            Task {
+                                let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
+                                selectedScopePreferences = prefs
+                                selectedScopeEntry = entry
+                            }
+                        },
+                        onSetEnabled: { scopeStore.setEnabled(entry.id, $0) },
+                        onDelete: {
+                            Task {
+                                await ScopePreferencesStore.shared.cleanUp(scope: entry.scope)
+                                scopeStore.remove(id: entry.id)
+                            }
+                        }
+                    )
+                }
             }
         }
-    }
-
-    // MARK: - Scope rows
-
-    /// Row view for a single remote scope entry.
-    ///
-    /// `displayName` and `alias` are read from `ScopeStore`'s cached observable state
-    /// (written back by `ScopePreferencesStore` on save), so this stays synchronous.
-    /// Full actor reads happen in the tap handler below.
-    private func scopeRow(_ entry: ScopeEntry) -> some View {
-        let isRepo = entry.scope.contains("/")
-        let displayName = entry.displayName ?? entry.scope
-        let hasAlias = entry.displayName != nil
-        return Button {
-            // Guard against double-taps: if a sheet is already being prepared or presented,
-            // ignore the second tap entirely. Without this, two simultaneous Tasks could
-            // complete out-of-order and pair selectedScopePreferences from scope A with
-            // selectedScopeEntry for scope B. (#1538)
-            guard selectedScopeEntry == nil else { return }
-            // Fetch preferences from the actor before presenting the sheet.
-            // Plain Task{} — inherits @MainActor, sheet presentation happens
-            // on main actor after the await. (P9)
-            Task {
-                let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
-                selectedScopePreferences = prefs
-                selectedScopeEntry = entry
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Text(isRepo ? "Repo" : "Org")
-                    .font(.caption2)
-                    .foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.rbSurfaceElevated))
-                    .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(displayName)
-                        .font(.system(size: 12))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    if hasAlias {
-                        Text(entry.scope)
-                            .font(.caption2)
-                            .foregroundColor(Color.rbTextTertiary)
-                            .lineLimit(1).truncationMode(.middle)
-                    }
-                }
-                Spacer()
-                Text(entry.isEnabled ? "Active" : "Paused")
-                    .font(.caption2)
-                    .foregroundColor(entry.isEnabled ? Color.rbSuccess : Color.rbTextTertiary)
-                Toggle("", isOn: Binding(
-                    get: { entry.isEnabled },
-                    // ScopeStore enable/disable is observed by RunnerStore.startObservingScopes
-                    // via withObservationTracking — no explicit restart needed here.
-                    set: { scopeStore.setEnabled(entry.id, $0) }
-                ))
-                .toggleStyle(.switch)
-                .tint(Color.rbSuccess)
-                .labelsHidden()
-                .help(entry.isEnabled ? "Pause monitoring" : "Resume monitoring")
-                .scaleEffect(0.8, anchor: .trailing)
-                .buttonStyle(.borderless)
-                Image(systemName: "chevron.right")
-                    .font(.caption2)
-                    .foregroundColor(Color.rbTextTertiary)
-                Button {
-                    // cleanUp MUST complete before remove so that the poll loop
-                    // restart triggered by ScopeStore.remove cannot race a
-                    // not-yet-cleaned preferences blob on the next tick. (#1538)
-                    Task {
-                        await ScopePreferencesStore.shared.cleanUp(scope: entry.scope)
-                        scopeStore.remove(id: entry.id)
-                        // ScopeStore.remove mutates activeScopes, firing
-                        // withObservationTracking in startObservingScopes and
-                        // restarting the poll loop automatically.
-                    }
-                } label: {
-                    Image(systemName: "minus.circle")
-                        .font(.caption2)
-                        .foregroundColor(Color.rbDanger)
-                }
-                .buttonStyle(.borderless)
-                .help("Remove scope")
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, RBSpacing.md)
-        .padding(.vertical, 5)
-        .settingsGlassCard(background: .rbGlassNeutralBackground, cornerRadius: RBRadius.small)
-        .padding(.horizontal, RBSpacing.xs)
-        .opacity(entry.isEnabled ? 1.0 : 0.5)
     }
 }

--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -1,6 +1,7 @@
 // AppDetailView.swift
 // RunBot
 
+import GitHubClient
 import SwiftUI
 
 /// Detail column router. Switches on the current sidebar selection.
@@ -8,6 +9,9 @@ import SwiftUI
 struct AppDetailView: View {
     /// The currently selected sidebar section.
     let selection: AppSection?
+
+    /// Injected from `AppShellView`; forwarded to scope management.
+    let authentication: GitHubAuthentication
 
     /// Routes to the corresponding feature-root view.
     var body: some View {
@@ -17,7 +21,7 @@ struct AppDetailView: View {
         case .localRunners:
             MigrationRunnerView()
         case .scopes:
-            MigrationScopeView()
+            MigrationScopeView(scopeStore: .shared, authentication: authentication)
         case .settings:
             MigrationSettingsView()
         case nil:

--- a/Sources/RunBot/migration/AppShell/AppShellView.swift
+++ b/Sources/RunBot/migration/AppShell/AppShellView.swift
@@ -9,6 +9,9 @@ struct AppShellView: View {
     /// Currently selected sidebar section. Defaults to Workflows.
     @State private var selection: AppSection? = .workflows
 
+    /// App-level state; source of authentication for child views.
+    @Environment(AppState.self) private var appState: AppState
+
     /// The top-level split-view layout.
     var body: some View {
         NavigationSplitView {
@@ -19,7 +22,7 @@ struct AppShellView: View {
                     max: 260
                 )
         } detail: {
-            AppDetailView(selection: selection)
+            AppDetailView(selection: selection, authentication: appState.authentication)
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 720, minHeight: 480)

--- a/Sources/RunBot/migration/AppShell/AppShellView.swift
+++ b/Sources/RunBot/migration/AppShell/AppShellView.swift
@@ -1,6 +1,7 @@
 // AppShellView.swift
 // RunBot
 
+import GitHubClient
 import SwiftUI
 
 /// Root two-column navigation shell.
@@ -9,8 +10,8 @@ struct AppShellView: View {
     /// Currently selected sidebar section. Defaults to Workflows.
     @State private var selection: AppSection? = .workflows
 
-    /// App-level state; source of authentication for child views.
-    @Environment(AppState.self) private var appState: AppState
+    /// Authentication injected from `RunBotDesktopApp`.
+    @Environment(GitHubAuthentication.self) private var authentication: GitHubAuthentication
 
     /// The top-level split-view layout.
     var body: some View {
@@ -22,7 +23,7 @@ struct AppShellView: View {
                     max: 260
                 )
         } detail: {
-            AppDetailView(selection: selection, authentication: appState.authentication)
+            AppDetailView(selection: selection, authentication: authentication)
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 720, minHeight: 480)

--- a/Sources/RunBot/migration/Features/Scopes/MigrationScopeDetailView.swift
+++ b/Sources/RunBot/migration/Features/Scopes/MigrationScopeDetailView.swift
@@ -1,0 +1,54 @@
+// MigrationScopeDetailView.swift
+// RunBot
+
+import RunBotCore
+import SwiftUI
+
+// MARK: - MigrationScopeDetailView
+
+/// Right pane of the Scopes split view: displays information for the selected scope.
+struct MigrationScopeDetailView: View {
+
+    // MARK: - Inputs
+
+    /// The currently selected scope, or `nil` when nothing is selected.
+    let scope: ScopeEntry?
+    /// Called when the Edit scope button is tapped.
+    let onEdit: (ScopeEntry) -> Void
+
+    // MARK: - Body
+
+    /// The detail pane layout.
+    var body: some View {
+        if let scope {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text(scope.displayName ?? scope.scope)
+                        .font(.title2.weight(.semibold))
+                        .lineLimit(2)
+
+                    LabeledContent("Scope", value: scope.scope)
+                    LabeledContent(
+                        "Type",
+                        value: scope.scope.contains("/") ? "Repository" : "Organization"
+                    )
+                    LabeledContent(
+                        "Status",
+                        value: scope.isEnabled ? "Enabled" : "Disabled"
+                    )
+
+                    Button("Edit scope") {
+                        onEdit(scope)
+                    }
+                }
+                .padding(20)
+                .frame(maxWidth: 640, alignment: .leading)
+            }
+        } else {
+            MigrationColumnPlaceholder(
+                title: "Select a scope",
+                systemImage: "scope"
+            )
+        }
+    }
+}

--- a/Sources/RunBot/migration/Features/Scopes/MigrationScopeListView.swift
+++ b/Sources/RunBot/migration/Features/Scopes/MigrationScopeListView.swift
@@ -1,0 +1,66 @@
+// MigrationScopeListView.swift
+// RunBot
+
+import RunBotCore
+import SwiftUI
+
+// MARK: - MigrationScopeListView
+
+/// Left pane of the Scopes split view: header, add button, and scope list.
+struct MigrationScopeListView: View {
+
+    // MARK: - Inputs
+
+    /// All registered scopes from `ScopeStore`.
+    let scopes: [ScopeEntry]
+    /// The currently selected scope ID, driven by the parent.
+    @Binding var selectedScopeID: ScopeEntry.ID?
+    /// Called when the Add scope button is tapped.
+    let onAdd: () -> Void
+    /// Called when the row toggle is flipped.
+    let onSetEnabled: (ScopeEntry, Bool) -> Void
+    /// Called when the row delete button is tapped.
+    let onDelete: (ScopeEntry) -> Void
+
+    // MARK: - Body
+
+    /// The list pane layout.
+    var body: some View {
+        MigrationWorkflowColumn(title: "Scopes") {
+            VStack(spacing: 0) {
+                HStack {
+                    Button("Add scope", systemImage: "plus") {
+                        onAdd()
+                    }
+                    .buttonStyle(.plain)
+                    .font(.caption)
+                    Spacer()
+                }
+                .padding(12)
+
+                Divider()
+
+                if scopes.isEmpty {
+                    MigrationColumnPlaceholder(
+                        title: "No scopes",
+                        systemImage: "scope",
+                        description: "Add a repository or organization to monitor."
+                    )
+                } else {
+                    List(scopes, selection: $selectedScopeID) { scope in
+                        ScopeRowView(
+                            scope: scope,
+                            onSelect: { selectedScopeID = scope.id },
+                            onSetEnabled: { onSetEnabled(scope, $0) },
+                            onDelete: { onDelete(scope) }
+                        )
+                        .tag(scope.id)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+        }
+    }
+}

--- a/Sources/RunBot/migration/Features/Scopes/MigrationScopeView.swift
+++ b/Sources/RunBot/migration/Features/Scopes/MigrationScopeView.swift
@@ -1,18 +1,138 @@
 // MigrationScopeView.swift
 // RunBot
 
+import GitHubClient
+import MenuBarKit
+import RunBotCore
 import SwiftUI
 
-/// Placeholder root view for the Scopes destination.
-/// Internal layout is introduced in a later migration step.
+// MARK: - MigrationScopeView
+
+/// Root view for the Scopes destination in the migration app shell.
+///
+/// Owns all scope-specific state and sheet presentation. The `scopeStore`
+/// is resolved once at the composition boundary in `AppDetailView` so child
+/// views do not each pull from `.shared`.
+///
+/// No `onRestartPolling` callback is needed — `ScopeStore` mutations are
+/// observed by `RunnerStore`'s `withObservationTracking` loop automatically.
+@MainActor
 struct MigrationScopeView: View {
-    /// The placeholder content.
-    var body: some View {
-        ContentUnavailableView(
-            "Scopes",
-            systemImage: "scope",
-            description: Text("Scope management will be added in a later migration step.")
+
+    // MARK: - Inputs
+
+    /// The shared scope store, injected at the composition boundary.
+    let scopeStore: ScopeStore
+
+    /// Authentication forwarded from the app shell for `AddScopeSheet`.
+    let authentication: GitHubAuthentication
+
+    // MARK: - Local UI state
+
+    /// The ID of the currently selected scope in the list pane.
+    @State private var selectedScopeID: ScopeEntry.ID?
+    /// Controls presentation of `AddScopeSheet`.
+    @State private var isAddScopePresented = false
+    /// Non-nil while `ScopeEditSheet` is being prepared or presented.
+    @State private var editedScope: ScopeEntry?
+    /// Preferences snapshot for `editedScope`. Fetched async before sheet
+    /// appears so `ScopeEditSheet.init` stays synchronous. (#1538)
+    @State private var editedScopePreferences: ScopePreferences?
+
+    // MARK: - Environment
+
+    /// Overlay gate managed by mbkSheet automatically.
+    @Environment(MBKOverlayGate.self) private var overlayGate: MBKOverlayGate
+
+    // MARK: - Computed
+
+    /// The full `ScopeEntry` for the current `selectedScopeID`, if any.
+    /// Full entry for `selectedScopeID`, or `nil` when nothing is selected.
+    private var selectedScope: ScopeEntry? {
+        scopeStore.entries.first { $0.id == selectedScopeID }
+    }
+
+    /// Bool binding mapping `editedScope` nil/non-nil for `mbkSheet(isPresented:)`.
+    /// Bool binding mapping `editedScope` nil/non-nil for `mbkSheet(isPresented:)`.
+    private var isEditSheetPresented: Binding<Bool> {
+        Binding(
+            get: { editedScope != nil },
+            set: { if !$0 { editedScope = nil; editedScopePreferences = nil } }
         )
-        .navigationTitle("Scopes")
+    }
+
+    // MARK: - Body
+
+    /// The root HSplitView layout with sheet bindings.
+    var body: some View {
+        HSplitView {
+            MigrationScopeListView(
+                scopes: scopeStore.entries,
+                selectedScopeID: $selectedScopeID,
+                onAdd: { isAddScopePresented = true },
+                onSetEnabled: setEnabled,
+                onDelete: delete
+            )
+            .frame(minWidth: 220, idealWidth: 280, maxWidth: 400)
+
+            MigrationScopeDetailView(
+                scope: selectedScope,
+                onEdit: prepareEdit
+            )
+            .frame(minWidth: 360, idealWidth: 520, maxWidth: 900)
+        }
+        .mbkSheet(isPresented: $isAddScopePresented) {
+            AddScopeSheet(
+                isPresented: $isAddScopePresented,
+                authentication: authentication
+            )
+        }
+        .mbkSheet(isPresented: isEditSheetPresented) {
+            if let entry = editedScope, let prefs = editedScopePreferences {
+                ScopeEditSheet(
+                    scopeEntry: entry,
+                    preferences: prefs,
+                    isPresented: isEditSheetPresented
+                )
+            } else {
+                EmptyView()
+            }
+        }
+        .onChange(of: editedScope) { _, newEntry in
+            if newEntry == nil { editedScopePreferences = nil }
+        }
+        // If a store refresh removes the selected scope, clear the selection.
+        .onChange(of: scopeStore.entries) { _, newEntries in
+            if let id = selectedScopeID,
+               !newEntries.contains(where: { $0.id == id }) {
+                selectedScopeID = nil
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Flips the enabled state via the store (observed by RunnerStore automatically).
+    private func setEnabled(_ entry: ScopeEntry, _ enabled: Bool) {
+        scopeStore.setEnabled(entry.id, enabled)
+    }
+
+    /// Cleans up preferences then removes the scope; clears selection if needed.
+    private func delete(_ entry: ScopeEntry) {
+        if selectedScopeID == entry.id { selectedScopeID = nil }
+        Task {
+            await ScopePreferencesStore.shared.cleanUp(scope: entry.scope)
+            scopeStore.remove(id: entry.id)
+        }
+    }
+
+    /// Fetches preferences asynchronously then presents the edit sheet.
+    private func prepareEdit(_ entry: ScopeEntry) {
+        guard editedScope == nil else { return }
+        Task {
+            let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
+            editedScopePreferences = prefs
+            editedScope = entry
+        }
     }
 }

--- a/Sources/RunBot/migration/Features/Scopes/MigrationScopeView.swift
+++ b/Sources/RunBot/migration/Features/Scopes/MigrationScopeView.swift
@@ -39,11 +39,6 @@ struct MigrationScopeView: View {
     /// appears so `ScopeEditSheet.init` stays synchronous. (#1538)
     @State private var editedScopePreferences: ScopePreferences?
 
-    // MARK: - Environment
-
-    /// Overlay gate managed by mbkSheet automatically.
-    @Environment(MBKOverlayGate.self) private var overlayGate: MBKOverlayGate
-
     // MARK: - Computed
 
     /// The full `ScopeEntry` for the current `selectedScopeID`, if any.

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -1,6 +1,7 @@
 // RunBotDesktopApp.swift
 // RunBot
 
+import GitHubClient
 import SwiftUI
 
 // @main removed: Sources/RunBot/main.swift is top-level code.
@@ -9,10 +10,14 @@ import SwiftUI
 /// The SwiftUI application entry point for RunBot.
 /// `@main` is intentionally absent because `main.swift` invokes `main()`.
 struct RunBotDesktopApp: App {
+    /// Authentication state owned at the window level and injected into the view hierarchy.
+    @State private var authentication = GitHubAuthentication()
+
     /// The scene graph for the windowed application.
     var body: some Scene {
         Window("RunBot", id: "main") {
             AppShellView()
+                .environment(authentication)
         }
         .defaultSize(width: 1_200, height: 760)
         .windowResizability(.contentMinSize)


### PR DESCRIPTION
Part of #2793
Stacked on #2811

## What
Replaces the Scopes placeholder with a two-pane scope-management view.

The left pane displays existing scope rows and an Add scope action.
The right pane displays information for the selected scope and exposes the existing edit flow.

## Changes
- Replace `MigrationScopeView` placeholder with a two-pane `HSplitView`
- Add scope-list pane with finite min/ideal/max widths (220-400 pt)
- Add selected-scope detail pane (360-900 pt)
- Extract legacy scope row into reusable `ScopeRowView`
- Update legacy `ScopesView` to use the extracted row without changing behavior
- Reuse `AddScopeSheet` and `ScopeEditSheet`
- Wire enable/disable and delete through the existing scope store
- Clear selection when the selected scope is removed

## Out of scope
- Workflow store wiring and step-log rendering
- Runner and settings migration
- Scope-selection restoration
- Polling or AppState redesign
- New scope models or duplicated sheets
- Visual redesign of the legacy scope row
- New UI or formatting tests

Closes #2813

## Summary by Sourcery

Introduce a split-view scopes management UI in the migration shell and share the existing scope row component between legacy settings and the new view.

New Features:
- Add a migration Scopes screen with a two-pane HSplitView for listing scopes and showing selected-scope details.
- Display selected scope metadata and an edit entry point in a dedicated detail pane within the migration app.
- Wire the migration Scopes view to the shared ScopeStore and app authentication, supporting add, enable/disable, delete, and edit flows.

Enhancements:
- Extract the legacy scope row into a reusable ScopeRowView and update the existing ScopesView to use it without changing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Scopes placeholder with a split-view manager and moves GitHub auth to the SwiftUI Environment. Previously this route showed a placeholder and auth was taken from AppState; now users can list, select, add, edit, enable/disable, and delete scopes, and `GitHubAuthentication` flows from the window environment. Runner polling behavior remains unchanged.

- Injects `GitHubAuthentication` via Environment: `RunBotDesktopApp` owns it, `AppShellView` reads it, and `AppDetailView` forwards it to `MigrationScopeView` (removes `AppState` coupling); `AddScopeSheet` uses this value. Imports `@GitHubClient`.
- `MigrationScopeView` owns scope state, presents `AddScopeSheet`/`ScopeEditSheet` with `mbkSheet` from `@MenuBarKit`, and fetches preferences before edit to keep sheet init synchronous.
- Adds `MigrationScopeListView` and `MigrationScopeDetailView`; clears selection if the selected scope is removed.
- Extracts reusable `ScopeRowView`; legacy `ScopesView` adopts it without behavior changes.
- Enable/disable calls `scopeStore.setEnabled`; delete awaits `ScopePreferencesStore.cleanUp` before `scopeStore.remove`. Polling restart remains automatic via observation.

<sup>Written for commit 1c58d769fd7e601076dd3030f7069627d0b799d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

