### PR TITLE
feat: migrate local runner management

### DIFF
--- a/Sources/RunBot/Views/Settings/LocalRunnerRowView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnerRowView.swift
@@ -1,0 +1,76 @@
+// LocalRunnerRowView.swift
+// RunBot
+import RunBotCore
+import SwiftUI
+
+// MARK: - LocalRunnerRowView
+
+/// Reusable row for a single configured local runner with start/stop and delete controls.
+///
+/// Extracted from `LocalRunnersView` for reuse in the migration two-pane layout.
+/// Toggle and delete taps do not propagate to `onSelect`.
+struct LocalRunnerRowView: View {
+
+    // MARK: - Inputs
+
+    let runner: RunnerModel
+    let onSelect: () -> Void
+    let onSetRunning: (Bool) -> Void
+    let onDelete: () -> Void
+
+    // MARK: - Body
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(runner.statusColor.color)
+                    .frame(width: 8, height: 8)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(runner.runnerName)
+                        .font(.system(size: 13))
+                        .lineLimit(1)
+
+                    if let url = runner.gitHubUrl {
+                        Text(url.absoluteString)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+
+                Spacer()
+
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { runner.isRunning },
+                        set: { onSetRunning($0) }
+                    )
+                )
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(Color.rbSuccess)
+                .scaleEffect(0.8, anchor: .trailing)
+                .buttonStyle(.borderless)
+
+                Button(
+                    action: onDelete,
+                    label: {
+                        Image(systemName: "minus.circle")
+                            .font(.caption2)
+                            .foregroundStyle(Color.rbDanger)
+                    }
+                )
+                .buttonStyle(.plain)
+                .help("Remove runner")
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 5)
+    }
+}

--- a/Sources/RunBot/Views/Settings/LocalRunnerRowView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnerRowView.swift
@@ -13,13 +13,18 @@ struct LocalRunnerRowView: View {
 
     // MARK: - Inputs
 
+    /// The runner model displayed by this row.
     let runner: RunnerModel
+    /// Called when the row body is tapped to select the runner.
     let onSelect: () -> Void
+    /// Called when the start/stop toggle changes; receives the new value.
     let onSetRunning: (Bool) -> Void
+    /// Called when the remove button is tapped.
     let onDelete: () -> Void
 
     // MARK: - Body
 
+    /// The row layout: status dot, name, URL, toggle, delete button.
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 6) {

--- a/Sources/RunBot/Views/Settings/Sheets/RunnerDetailContentView.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/RunnerDetailContentView.swift
@@ -14,15 +14,19 @@ struct RunnerDetailContentView: View {
 
     // MARK: - Inputs
 
+    /// The runner whose information and configuration are displayed.
     let runner: RunnerModel
 
     // MARK: - Display fields (loaded from .runner JSON)
 
+    /// OS and architecture string loaded asynchronously from the runner JSON file.
     @State private var displayOsArch: String = ""
+    /// Agent version string loaded asynchronously from the runner JSON file.
     @State private var displayVersion: String = ""
 
     // MARK: - Body
 
+    /// Scrollable info and configuration panels for the runner.
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -66,6 +70,7 @@ struct RunnerDetailContentView: View {
 
     // MARK: - Helpers
 
+    /// Returns a styled section header label.
     private func sectionHeader(_ title: String) -> some View {
         Text(title)
             .font(RBFont.sectionHeader)
@@ -75,6 +80,7 @@ struct RunnerDetailContentView: View {
             .padding(.bottom, 4)
     }
 
+    /// Returns a glass-card container wrapping the provided content.
     private func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 0) { content() }
             .glassCard(cornerRadius: RBRadius.small)
@@ -82,6 +88,7 @@ struct RunnerDetailContentView: View {
             .padding(.bottom, 8)
     }
 
+    /// Returns a two-column label/value row with an optional copy-to-clipboard button.
     private func infoRow(label: String, value: String, copyable: Bool = false) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(label)
@@ -114,6 +121,7 @@ struct RunnerDetailContentView: View {
 
     // MARK: - Load display fields
 
+    /// Reads OS/arch and version from the runner JSON file and updates display state.
     @MainActor
     private func loadDisplayFields() async {
         guard let installPath = runner.installPath else { return }
@@ -127,6 +135,6 @@ struct RunnerDetailContentView: View {
         let combined = [config.platform, config.platformArchitecture]
             .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " / ")
         if !combined.isEmpty { displayOsArch = combined }
-        if let v = config.agentVersion, !v.isEmpty { displayVersion = v }
+        if let version = config.agentVersion, !version.isEmpty { displayVersion = version }
     }
 }

--- a/Sources/RunBot/Views/Settings/Sheets/RunnerDetailContentView.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/RunnerDetailContentView.swift
@@ -1,0 +1,132 @@
+// RunnerDetailContentView.swift
+// RunBot
+import RunBotCore
+import SwiftUI
+
+// MARK: - RunnerDetailContentView
+
+/// Reusable read-only body extracted from `RunnerDetailSheet`.
+///
+/// Used directly in the migration two-pane detail pane so the detail pane
+/// does not present a modal sheet inside itself.
+/// `RunnerDetailSheet` keeps wrapping this view for the legacy panel flow.
+struct RunnerDetailContentView: View {
+
+    // MARK: - Inputs
+
+    let runner: RunnerModel
+
+    // MARK: - Display fields (loaded from .runner JSON)
+
+    @State private var displayOsArch: String = ""
+    @State private var displayVersion: String = ""
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                sectionHeader("Runner Info")
+                infoCard {
+                    if let url = runner.gitHubUrl {
+                        infoRow(label: "GitHub URL", value: url.absoluteString, copyable: true)
+                        Divider().padding(.leading, RBSpacing.md)
+                    }
+                    infoRow(label: "Work folder", value: runner.workFolder ?? "_work")
+                    Divider().padding(.leading, RBSpacing.md)
+                    infoRow(label: "Ephemeral", value: runner.isEphemeral ? "Yes" : "No")
+                    if !displayOsArch.isEmpty {
+                        Divider().padding(.leading, RBSpacing.md)
+                        infoRow(label: "OS / Arch", value: displayOsArch)
+                    }
+                    if !displayVersion.isEmpty {
+                        Divider().padding(.leading, RBSpacing.md)
+                        infoRow(label: "Version", value: displayVersion)
+                    }
+                    Divider().padding(.leading, RBSpacing.md)
+                    infoRow(label: "Status", value: runner.displayStatus)
+                }
+
+                sectionHeader("Configuration")
+                infoCard {
+                    if runner.labels.isEmpty {
+                        infoRow(label: "Labels", value: "—")
+                    } else {
+                        infoRow(label: "Labels", value: runner.labels.joined(separator: ", "))
+                    }
+                    Divider().padding(.leading, RBSpacing.md)
+                    infoRow(label: "Group", value: runner.runnerGroup ?? "—")
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: 640, alignment: .leading)
+        }
+        .task { await loadDisplayFields() }
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(RBFont.sectionHeader)
+            .foregroundStyle(Color.rbTextSecondary)
+            .padding(.horizontal, RBSpacing.md)
+            .padding(.top, 12)
+            .padding(.bottom, 4)
+    }
+
+    private func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 0) { content() }
+            .glassCard(cornerRadius: RBRadius.small)
+            .padding(.horizontal, RBSpacing.md)
+            .padding(.bottom, 8)
+    }
+
+    private func infoRow(label: String, value: String, copyable: Bool = false) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.rbTextSecondary)
+                .frame(width: 100, alignment: .leading)
+                .fixedSize()
+            Text(value)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(Color.rbTextPrimary)
+                .lineLimit(2)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if copyable {
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(value, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.rbTextTertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Copy to clipboard")
+            }
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 7)
+    }
+
+    // MARK: - Load display fields
+
+    @MainActor
+    private func loadDisplayFields() async {
+        guard let installPath = runner.installPath else { return }
+        var draft = RunnerEditDraft(runner: runner)
+        let config = await draft.load(
+            installPath: installPath,
+            configStore: RunnerConfigStore.shared,
+            proxyStore: RunnerProxyStore.shared
+        )
+        guard let config else { return }
+        let combined = [config.platform, config.platformArchitecture]
+            .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " / ")
+        if !combined.isEmpty { displayOsArch = combined }
+        if let v = config.agentVersion, !v.isEmpty { displayVersion = v }
+    }
+}

--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -14,8 +14,9 @@ struct AppDetailView: View {
     /// Injected from `AppShellView`; forwarded to scope management.
     let authentication: GitHubAuthentication
 
-    /// Runner store forwarded from the composition root.
+    /// Observable runner state pushed by `LocalRunnerStore`.
     let runnerState: RunnerState
+    /// Configured local-runner store forwarded from the composition root.
     let localRunnerStore: LocalRunnerStore
 
     /// Routes to the corresponding feature-root view.

--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -2,6 +2,7 @@
 // RunBot
 
 import GitHubClient
+import RunBotCore
 import SwiftUI
 
 /// Detail column router. Switches on the current sidebar selection.
@@ -13,13 +14,20 @@ struct AppDetailView: View {
     /// Injected from `AppShellView`; forwarded to scope management.
     let authentication: GitHubAuthentication
 
+    /// Runner store forwarded from the composition root.
+    let runnerState: RunnerState
+    let localRunnerStore: LocalRunnerStore
+
     /// Routes to the corresponding feature-root view.
     var body: some View {
         switch selection {
         case .workflows:
             MigrationWorkflowView(workflows: [])
         case .localRunners:
-            MigrationRunnerView()
+            MigrationRunnerView(
+                runnerState: runnerState,
+                localRunnerStore: localRunnerStore
+            )
         case .scopes:
             MigrationScopeView(scopeStore: .shared, authentication: authentication)
         case .settings:

--- a/Sources/RunBot/migration/AppShell/AppShellView.swift
+++ b/Sources/RunBot/migration/AppShell/AppShellView.swift
@@ -16,6 +16,7 @@ struct AppShellView: View {
 
     /// Runner store forwarded from the composition root.
     let runnerState: RunnerState
+    /// Configured local-runner store forwarded from the composition root.
     let localRunnerStore: LocalRunnerStore
 
     /// The top-level split-view layout.

--- a/Sources/RunBot/migration/AppShell/AppShellView.swift
+++ b/Sources/RunBot/migration/AppShell/AppShellView.swift
@@ -2,6 +2,7 @@
 // RunBot
 
 import GitHubClient
+import RunBotCore
 import SwiftUI
 
 /// Root two-column navigation shell.
@@ -13,6 +14,10 @@ struct AppShellView: View {
     /// Authentication injected from `RunBotDesktopApp`.
     @Environment(GitHubAuthentication.self) private var authentication: GitHubAuthentication
 
+    /// Runner store forwarded from the composition root.
+    let runnerState: RunnerState
+    let localRunnerStore: LocalRunnerStore
+
     /// The top-level split-view layout.
     var body: some View {
         NavigationSplitView {
@@ -23,7 +28,12 @@ struct AppShellView: View {
                     max: 260
                 )
         } detail: {
-            AppDetailView(selection: selection, authentication: authentication)
+            AppDetailView(
+                selection: selection,
+                authentication: authentication,
+                runnerState: runnerState,
+                localRunnerStore: localRunnerStore
+            )
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 720, minHeight: 480)

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerDetailView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerDetailView.swift
@@ -11,10 +11,12 @@ struct MigrationRunnerDetailView: View {
 
     // MARK: - Inputs
 
+    /// The runner whose detail should be displayed, or `nil` when nothing is selected.
     let runner: RunnerModel?
 
     // MARK: - Body
 
+    /// Shows `RunnerDetailContentView` when a runner is selected, otherwise a placeholder.
     var body: some View {
         if let runner {
             RunnerDetailContentView(runner: runner)

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerDetailView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerDetailView.swift
@@ -1,0 +1,28 @@
+// MigrationRunnerDetailView.swift
+// RunBot
+import RunBotCore
+import SwiftUI
+
+// MARK: - MigrationRunnerDetailView
+
+/// Right pane: displays information and configuration for the selected runner,
+/// or a placeholder when nothing is selected.
+struct MigrationRunnerDetailView: View {
+
+    // MARK: - Inputs
+
+    let runner: RunnerModel?
+
+    // MARK: - Body
+
+    var body: some View {
+        if let runner {
+            RunnerDetailContentView(runner: runner)
+        } else {
+            MigrationColumnPlaceholder(
+                title: "Select a local runner",
+                systemImage: "desktopcomputer"
+            )
+        }
+    }
+}

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerListView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerListView.swift
@@ -10,14 +10,20 @@ struct MigrationRunnerListView: View {
 
     // MARK: - Inputs
 
+    /// The current list of configured local runners.
     let runners: [RunnerModel]
+    /// The ID of the currently selected runner, driven by the parent.
     @Binding var selectedRunnerID: RunnerModel.ID?
+    /// Called when the Add local runner button is tapped.
     let onAdd: () -> Void
+    /// Called when a row start/stop toggle changes; receives the runner and new value.
     let onSetRunning: (RunnerModel, Bool) -> Void
+    /// Called when a row delete button is tapped; receives the runner to remove.
     let onDelete: (RunnerModel) -> Void
 
     // MARK: - Body
 
+    /// The column layout: header with Add action, divider, list or empty placeholder.
     var body: some View {
         MigrationWorkflowColumn(title: "Local runners") {
             VStack(spacing: 0) {

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerListView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerListView.swift
@@ -1,0 +1,59 @@
+// MigrationRunnerListView.swift
+// RunBot
+import RunBotCore
+import SwiftUI
+
+// MARK: - MigrationRunnerListView
+
+/// Left pane: list of configured local runners plus an Add action.
+struct MigrationRunnerListView: View {
+
+    // MARK: - Inputs
+
+    let runners: [RunnerModel]
+    @Binding var selectedRunnerID: RunnerModel.ID?
+    let onAdd: () -> Void
+    let onSetRunning: (RunnerModel, Bool) -> Void
+    let onDelete: (RunnerModel) -> Void
+
+    // MARK: - Body
+
+    var body: some View {
+        MigrationWorkflowColumn(title: "Local runners") {
+            VStack(spacing: 0) {
+                HStack {
+                    Button(action: onAdd) {
+                        Label("Add local runner", systemImage: "plus")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.plain)
+                    Spacer()
+                }
+                .padding(12)
+
+                Divider()
+
+                if runners.isEmpty {
+                    MigrationColumnPlaceholder(
+                        title: "No local runners",
+                        systemImage: "desktopcomputer",
+                        description: "Add a local self-hosted runner to manage it."
+                    )
+                } else {
+                    List(runners, selection: $selectedRunnerID) { runner in
+                        LocalRunnerRowView(
+                            runner: runner,
+                            onSelect: { selectedRunnerID = runner.id },
+                            onSetRunning: { onSetRunning(runner, $0) },
+                            onDelete: { onDelete(runner) }
+                        )
+                        .tag(runner.id)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+        }
+    }
+}

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerView.swift
@@ -15,22 +15,28 @@ struct MigrationRunnerView: View {
 
     // MARK: - Inputs
 
+    /// Observable runner state pushed by `LocalRunnerStore` via `MigrationAppDependencies`.
     let runnerState: RunnerState
+    /// The configured local-runner store; must be configured before this view mounts.
     let localRunnerStore: LocalRunnerStore
 
     // MARK: - Local UI state
 
+    /// The ID of the runner whose detail is displayed in the right pane.
     @State private var selectedRunnerID: RunnerModel.ID?
+    /// Controls presentation of `AddRunnerSheet`.
     @State private var isAddRunnerPresented = false
 
     // MARK: - Computed
 
+    /// The `RunnerModel` matching `selectedRunnerID`, or `nil` when nothing is selected.
     private var selectedRunner: RunnerModel? {
         runnerState.localRunners.first { $0.id == selectedRunnerID }
     }
 
     // MARK: - Body
 
+    /// Root `HSplitView` with list pane left and detail pane right.
     var body: some View {
         HSplitView {
             MigrationRunnerListView(
@@ -63,6 +69,7 @@ struct MigrationRunnerView: View {
 
     // MARK: - Actions
 
+    /// Optimistically flips the runner service state then refreshes.
     private func setRunning(_ runner: RunnerModel, isRunning: Bool) {
         Task {
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: isRunning)
@@ -70,6 +77,7 @@ struct MigrationRunnerView: View {
         }
     }
 
+    /// Clears selection immediately then optimistically removes the runner from the store.
     private func delete(_ runner: RunnerModel) {
         let wasSelected = runner.id == selectedRunnerID
         if wasSelected { selectedRunnerID = nil }

--- a/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerView.swift
+++ b/Sources/RunBot/migration/Features/LocalRunners/MigrationRunnerView.swift
@@ -1,18 +1,80 @@
 // MigrationRunnerView.swift
 // RunBot
-
+import MenuBarKit
+import RunBotCore
 import SwiftUI
 
-/// Placeholder root view for the Local runners destination.
-/// Internal layout is introduced in a later migration step.
+// MARK: - MigrationRunnerView
+
+/// Root two-pane local runner management view.
+///
+/// Receives an already-configured `LocalRunnerStore` from the composition root.
+/// The store must be configured before this view is mounted.
+@MainActor
 struct MigrationRunnerView: View {
-    /// The placeholder content.
+
+    // MARK: - Inputs
+
+    let runnerState: RunnerState
+    let localRunnerStore: LocalRunnerStore
+
+    // MARK: - Local UI state
+
+    @State private var selectedRunnerID: RunnerModel.ID?
+    @State private var isAddRunnerPresented = false
+
+    // MARK: - Computed
+
+    private var selectedRunner: RunnerModel? {
+        runnerState.localRunners.first { $0.id == selectedRunnerID }
+    }
+
+    // MARK: - Body
+
     var body: some View {
-        ContentUnavailableView(
-            "Local runners",
-            systemImage: "desktopcomputer",
-            description: Text("Local runner management will be added in a later migration step.")
-        )
-        .navigationTitle("Local runners")
+        HSplitView {
+            MigrationRunnerListView(
+                runners: runnerState.localRunners,
+                selectedRunnerID: $selectedRunnerID,
+                onAdd: { isAddRunnerPresented = true },
+                onSetRunning: setRunning,
+                onDelete: delete
+            )
+            .frame(minWidth: 220, idealWidth: 280, maxWidth: 400)
+
+            MigrationRunnerDetailView(runner: selectedRunner)
+                .frame(minWidth: 360, idealWidth: 520, maxWidth: 900)
+        }
+        .mbkSheet(isPresented: $isAddRunnerPresented) {
+            AddRunnerSheet(
+                isPresented: $isAddRunnerPresented,
+                onComplete: {
+                    Task { await localRunnerStore.refreshAsync() }
+                }
+            )
+        }
+        .onChange(of: runnerState.localRunners) { _, runners in
+            if let id = selectedRunnerID, !runners.contains(where: { $0.id == id }) {
+                selectedRunnerID = nil
+            }
+        }
+        .task { await localRunnerStore.refreshAsync() }
+    }
+
+    // MARK: - Actions
+
+    private func setRunning(_ runner: RunnerModel, isRunning: Bool) {
+        Task {
+            await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: isRunning)
+            await localRunnerStore.refreshAsync()
+        }
+    }
+
+    private func delete(_ runner: RunnerModel) {
+        let wasSelected = runner.id == selectedRunnerID
+        if wasSelected { selectedRunnerID = nil }
+        Task {
+            await localRunnerStore.optimisticallyRemove(runner.runnerName)
+        }
     }
 }

--- a/Sources/RunBot/migration/MigrationAppDependencies.swift
+++ b/Sources/RunBot/migration/MigrationAppDependencies.swift
@@ -1,0 +1,25 @@
+// MigrationAppDependencies.swift
+// RunBot
+import Observation
+import RunBotCore
+
+// MARK: - MigrationAppDependencies
+
+/// Owns and configures the minimum domain dependencies required by the windowed app.
+///
+/// `LocalRunnerStore.configure(viewModel:)` must be the very first call,
+/// synchronously, before any view is mounted. This mirrors the ordering rule
+/// documented in `AppDelegate+StoreSetup.swift` (fix for issue #1741).
+@MainActor
+@Observable
+final class MigrationAppDependencies {
+    let runnerState: RunnerState
+    let localRunnerStore: LocalRunnerStore
+
+    init() {
+        let state = RunnerState()
+        self.runnerState = state
+        LocalRunnerStore.configure(viewModel: state)
+        self.localRunnerStore = LocalRunnerStore.shared
+    }
+}

--- a/Sources/RunBot/migration/MigrationAppDependencies.swift
+++ b/Sources/RunBot/migration/MigrationAppDependencies.swift
@@ -13,9 +13,12 @@ import RunBotCore
 @MainActor
 @Observable
 final class MigrationAppDependencies {
+    /// Observable runner state that `LocalRunnerStore` pushes snapshots into.
     let runnerState: RunnerState
+    /// The configured local-runner store, ready for injection into views.
     let localRunnerStore: LocalRunnerStore
 
+    /// Configures `LocalRunnerStore` synchronously then captures the shared instance.
     init() {
         let state = RunnerState()
         self.runnerState = state

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -12,12 +12,18 @@ import SwiftUI
 struct RunBotDesktopApp: App {
     /// Authentication state owned at the window level and injected into the view hierarchy.
     @State private var authentication = GitHubAuthentication()
+    /// Runner dependencies configured synchronously before any view is mounted.
+    /// `LocalRunnerStore.configure` runs inside `MigrationAppDependencies.init()`.
+    @State private var deps = MigrationAppDependencies()
 
     /// The scene graph for the windowed application.
     var body: some Scene {
         Window("RunBot", id: "main") {
-            AppShellView()
-                .environment(authentication)
+            AppShellView(
+                runnerState: deps.runnerState,
+                localRunnerStore: deps.localRunnerStore
+            )
+            .environment(authentication)
         }
         .defaultSize(width: 1_200, height: 760)
         .windowResizability(.contentMinSize)


### PR DESCRIPTION
Part of #2793
Stacked on #2814

## What

Replaces the Local runners placeholder with a two-pane runner-management view.

The left pane displays configured local runners and an Add local runner action.
The right pane displays information and configuration for the selected runner.

## Changes

- Establish the minimum local-runner store setup required by the window app (`MigrationAppDependencies`).
- Inject the runner store from the app composition root (`RunBotDesktopApp` → `AppShellView` → `AppDetailView`).
- Replace `MigrationRunnerView` with a two-pane `HSplitView`.
- Add a configured-runner list pane with finite widths (`MigrationRunnerListView`).
- Add a selected-runner detail pane with finite widths (`MigrationRunnerDetailView`).
- Extract the existing configured-runner row into `LocalRunnerRowView`.
- Extract reusable detail content from `RunnerDetailSheet` into `RunnerDetailContentView`.
- Keep `RunnerDetailSheet` as the legacy presentation wrapper (unchanged).
- Reuse `AddRunnerSheet` with `isPresented` binding and `onComplete` refresh callback.
- Wire enable/disable (`optimisticallySetRunning`), delete (`optimisticallyRemove`), refresh, and selection cleanup.

## Out of scope

- Workflow store and log wiring.
- Metrics and active-runner telemetry.
- Runner-selection restoration.
- Native sheet migration.
- Polling, updater, OAuth, or status-item redesign.
- New runner domain models.
- Visual redesign of reused components.
- New UI or formatting tests.

## Acceptance criteria

- [ ] Selecting Local runners displays a two-pane layout.
- [ ] The list pane cannot shrink below 220 pt.
- [ ] The detail pane cannot shrink below 360 pt.
- [ ] Configured runners use the extracted legacy row.
- [ ] Rows show runner name and URL.
- [ ] Selecting a runner displays its information and configuration.
- [ ] No selection displays a Select a local runner placeholder.
- [ ] Add local runner presents the existing `AddRunnerSheet`.
- [ ] Successful add refreshes the runner list.
- [ ] Enable/disable uses the existing runner-store operation.
- [ ] Delete uses the existing cleanup/removal sequence.
- [ ] Deleting the selected runner clears detail selection.
- [ ] Refreshing away a selected runner clears selection.
- [ ] Legacy `LocalRunnersView` behavior remains unchanged.
- [ ] The runner store is configured before any view accesses it.
- [ ] No broad AppState lifecycle is restored.
- [ ] No scope, workflow, settings, metrics, or restoration work is introduced.
- [ ] No new premature UI or formatting tests are added.
- [ ] `swift build` passes.
- [ ] `swift test` passes.
- [ ] SwiftLint passes.
- [ ] `build.sh` release build passes.

## Summary by Sourcery

Introduce a two-pane local runner management experience wired to a configured runner store and state.

New Features:
- Add a split-view Local runners screen with a list pane and a detail pane.
- Display runner information and configuration inline in the detail pane using a reusable content view.
- Provide inline controls on each runner row to add, select, start/stop, and delete local runners.

Enhancements:
- Inject RunnerState and LocalRunnerStore from the window app composition root into the migration shell and detail router.
- Establish a MigrationAppDependencies owner that synchronously configures the LocalRunnerStore before views are mounted.
- Extract the legacy local-runner row and runner detail body into reusable views for use in both legacy and migration flows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Local runners placeholder with a split list/detail manager backed by a synchronously configured `LocalRunnerStore`. Old: static placeholder. New: two‑pane management with list, inline details, and add/start/stop/delete. Legacy views remain unchanged.

- Configure `LocalRunnerStore` early via `MigrationAppDependencies` with `RunnerState`, injected through `RunBotDesktopApp` → `AppShellView` → `AppDetailView` → `MigrationRunnerView`.
- Use a two‑pane `HSplitView`: left `MigrationRunnerListView` + `LocalRunnerRowView`; right `MigrationRunnerDetailView` with `RunnerDetailContentView` or a placeholder. List min width 220 pt; detail min width 360 pt.
- Wire actions: start/stop via `optimisticallySetRunning`, delete via `optimisticallyRemove`; add uses `.mbkSheet` with `AddRunnerSheet`. Refresh after changes and clear selection when a runner is deleted or disappears.
- Add doc comments and identifier tweaks to satisfy SwiftLint missing_docs and identifier_name rules (no behavior changes).

**Migration**
- Ensure `LocalRunnerStore.configure(viewModel:)` runs synchronously before any view mounts (use `MigrationAppDependencies`).

<sup>Written for commit 21d0d22576bd0fd09b7710077c104c090763ade7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

