### PR TITLE
feat: migrate application settings

### DIFF
--- a/Sources/RunBot/Views/Settings/Components/AboutSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/AboutSettingsSection.swift
@@ -17,13 +17,16 @@ struct AboutSettingsSection: View {
 
     // MARK: - Version
 
+    /// The marketing version string from `Bundle.main.rbVersionString`.
     private var appVersion: String { Bundle.main.rbVersionString }
+    /// The build number from `CFBundleVersion`.
     private var appBuild: String {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
 
     // MARK: - Body
 
+    /// The about section card showing version, build, and pre-release badge.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("About")

--- a/Sources/RunBot/Views/Settings/Components/AboutSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/AboutSettingsSection.swift
@@ -1,0 +1,57 @@
+// AboutSettingsSection.swift
+// RunBot
+
+import SwiftUI
+
+// MARK: - AboutSettingsSection
+
+/// Reusable About section showing the canonical app version and build.
+///
+/// Uses `Bundle.main.rbVersionString` and `CFBundleVersion` — the same
+/// sources as `SettingsView+Sections.aboutSection`. Do not hardcode a version.
+///
+/// The pre-release caption is driven by `Bundle.main.isPreReleaseBuild`
+/// (see `Bundle+Version.swift`) rather than an inline `contains("-")` check,
+/// to keep detection logic in one place. See PR #2085 / #2108.
+struct AboutSettingsSection: View {
+
+    // MARK: - Version
+
+    private var appVersion: String { Bundle.main.rbVersionString }
+    private var appBuild: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("About")
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            HStack {
+                Text("RunBot").font(.system(size: 12))
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(appVersion) (\(appBuild))")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color.rbTextSecondary)
+                    if Bundle.main.isPreReleaseBuild {
+                        Text("Pre-release build")
+                            .font(.caption2)
+                            .foregroundColor(Color.rbTextTertiary)
+                    }
+                }
+            }
+            .padding(.horizontal, RBSpacing.md)
+            .padding(.vertical, 5)
+        }
+        .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 8)
+    }
+}

--- a/Sources/RunBot/Views/Settings/Components/GeneralSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/GeneralSettingsSection.swift
@@ -1,0 +1,57 @@
+// GeneralSettingsSection.swift
+// RunBot
+
+import RunBotCore
+import SwiftUI
+
+// MARK: - GeneralSettingsSection
+
+/// Reusable general-settings section extracted from `SettingsView+Sections`.
+///
+/// Owns the launch-at-login toggle and reads/writes `LoginItem`.
+/// The notification-preference row is intentionally absent: it controls
+/// menu-bar-popover behaviour that does not apply to the windowed destination.
+struct GeneralSettingsSection: View {
+
+    @State private var launchAtLogin = LoginItem.isEnabled
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("General")
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            VStack(spacing: 0) {
+                HStack(alignment: .center) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Launch at login").font(.system(size: 12))
+                        Text("Automatically launch RunBot when you log in.")
+                            .font(.caption2)
+                            .foregroundColor(Color.rbTextSecondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $launchAtLogin)
+                        .toggleStyle(.switch)
+                        .tint(Color.rbSuccess)
+                        .labelsHidden()
+                        .onChange(of: launchAtLogin) { _, newVal in
+                            applyLaunchAtLogin(newVal)
+                        }
+                }
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.vertical, 6)
+            }
+            .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
+            .padding(.horizontal, RBSpacing.md)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private func applyLaunchAtLogin(_ enabled: Bool) {
+        LoginItem.setEnabled(enabled)
+        launchAtLogin = LoginItem.isEnabled
+    }
+}

--- a/Sources/RunBot/Views/Settings/Components/GeneralSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/GeneralSettingsSection.swift
@@ -13,8 +13,10 @@ import SwiftUI
 /// menu-bar-popover behaviour that does not apply to the windowed destination.
 struct GeneralSettingsSection: View {
 
+    /// Whether RunBot is registered as a Login Item.
     @State private var launchAtLogin = LoginItem.isEnabled
 
+    /// The launch-at-login settings card.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General")
@@ -50,6 +52,7 @@ struct GeneralSettingsSection: View {
         }
     }
 
+    /// Writes the Login Item entry then re-reads state so the toggle snaps on failure.
     private func applyLaunchAtLogin(_ enabled: Bool) {
         LoginItem.setEnabled(enabled)
         launchAtLogin = LoginItem.isEnabled

--- a/Sources/RunBot/Views/Settings/Components/UpdateSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/UpdateSettingsSection.swift
@@ -1,0 +1,158 @@
+// UpdateSettingsSection.swift
+// RunBot
+
+import AppUpdater
+import RunBotCore
+import SwiftUI
+
+// MARK: - UpdateSettingsSection
+
+/// Reusable update-settings section extracted from `SettingsView+Sections`.
+///
+/// Renders:
+/// - Automatic updates toggle.
+/// - Beta channel toggle (only when automatic updates are enabled).
+/// - Update action row (only when a non-idle update phase is active).
+///
+/// The updater is injected so it is never instantiated inside this view.
+/// Instantiate once at the composition root and thread through
+/// `MigrationSettingsDependencies`.
+struct UpdateSettingsSection: View {
+
+    /// App-wide preference store — needs @Bindable for two-way toggle bindings.
+    @Bindable var settings: AppPreferencesStore
+    /// Observable runner state — read to drive the update action row.
+    let runnerState: RunnerState
+    /// The shared auto-updater; must be owned at the composition root.
+    let autoUpdater: AppUpdater
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Updates")
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            VStack(spacing: 0) {
+                automaticUpdatesRow
+                if settings.automaticUpdatesEnabled {
+                    Divider().padding(.leading, RBSpacing.md)
+                    betaChannelRow
+                }
+                if settings.automaticUpdatesEnabled && runnerState.currentPhase != .idle {
+                    Divider().padding(.leading, RBSpacing.md)
+                    GlassEffectContainer {
+                        updateActionRow
+                    }
+                }
+            }
+            .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
+            .padding(.horizontal, RBSpacing.md)
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Rows
+
+    private var automaticUpdatesRow: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Automatic updates").font(.system(size: 12))
+                Text("Automatically downloads updates from GitHub Releases, verified with Ed25519.")
+                    .font(.caption2).foregroundColor(Color.rbTextSecondary)
+            }
+            Spacer()
+            Toggle("", isOn: $settings.automaticUpdatesEnabled)
+                .toggleStyle(.switch)
+                .tint(Color.rbSuccess)
+                .labelsHidden()
+                .onChange(of: settings.automaticUpdatesEnabled) { _, enabled in
+                    if enabled {
+                        Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                    }
+                }
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 6)
+    }
+
+    private var betaChannelRow: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Beta channel").font(.system(size: 12))
+                Text("Receive pre-release builds when checking for updates. Does not affect your currently installed version.")
+                    .font(.caption2).foregroundColor(Color.rbTextSecondary)
+            }
+            Spacer()
+            Toggle("", isOn: $settings.betaChannel)
+                .toggleStyle(.switch)
+                .tint(Color.rbSuccess)
+                .labelsHidden()
+                .onChange(of: settings.betaChannel) { _, _ in
+                    if settings.automaticUpdatesEnabled {
+                        Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                    }
+                }
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 6)
+    }
+
+    @ViewBuilder
+    private var updateActionRow: some View {
+        HStack {
+            switch runnerState.currentPhase {
+            case .idle:
+                EmptyView()
+            case .available(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available: \(version)").font(.system(size: 12))
+                    Text("A new version is available. Click to download and install.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Button("Install & Relaunch") {}
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(true)
+            case .downloading(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available: \(version)").font(.system(size: 12))
+                    ProgressView("Downloading update…")
+                        .scaleEffect(RBMetrics.updateProgressScale)
+                }
+                Spacer()
+            case .ready(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available: \(version)").font(.system(size: 12))
+                    Text("A new version of the app is ready to be installed.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Button("Install & Relaunch") {
+                    Task { await autoUpdater.installAndRelaunch(state: runnerState) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .help("Install and relaunch RunBot")
+            case .failed(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available" + (version.map { ": \($0)" } ?? ""))
+                        .font(.system(size: 12))
+                    Text("Download failed. Check your connection and try again.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Button("Retry") {
+                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(10)
+    }
+}

--- a/Sources/RunBot/Views/Settings/Components/UpdateSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/UpdateSettingsSection.swift
@@ -19,13 +19,14 @@ import SwiftUI
 /// `MigrationSettingsDependencies`.
 struct UpdateSettingsSection: View {
 
-    /// App-wide preference store — needs @Bindable for two-way toggle bindings.
+    /// App-wide preference store; needs `@Bindable` for two-way toggle bindings.
     @Bindable var settings: AppPreferencesStore
     /// Observable runner state — read to drive the update action row.
     let runnerState: RunnerState
     /// The shared auto-updater; must be owned at the composition root.
     let autoUpdater: AppUpdater
 
+    /// The updates settings card.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Updates")
@@ -56,6 +57,7 @@ struct UpdateSettingsSection: View {
 
     // MARK: - Rows
 
+    /// Row toggling automatic update downloads.
     private var automaticUpdatesRow: some View {
         HStack(alignment: .center) {
             VStack(alignment: .leading, spacing: 2) {
@@ -78,6 +80,7 @@ struct UpdateSettingsSection: View {
         .padding(.vertical, 6)
     }
 
+    /// Row toggling the beta update channel.
     private var betaChannelRow: some View {
         HStack(alignment: .center) {
             VStack(alignment: .leading, spacing: 2) {
@@ -100,6 +103,7 @@ struct UpdateSettingsSection: View {
         .padding(.vertical, 6)
     }
 
+    /// Row showing download progress or install action for a pending update.
     @ViewBuilder
     private var updateActionRow: some View {
         HStack {

--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -18,6 +18,8 @@ struct AppDetailView: View {
     let runnerState: RunnerState
     /// Configured local-runner store forwarded from the composition root.
     let localRunnerStore: LocalRunnerStore
+    /// Settings services forwarded from the composition root.
+    let settingsDependencies: MigrationSettingsDependencies
 
     /// Routes to the corresponding feature-root view.
     var body: some View {
@@ -32,7 +34,7 @@ struct AppDetailView: View {
         case .scopes:
             MigrationScopeView(scopeStore: .shared, authentication: authentication)
         case .settings:
-            MigrationSettingsView()
+            MigrationSettingsView(dependencies: settingsDependencies)
         case nil:
             ContentUnavailableView(
                 "Select an item",

--- a/Sources/RunBot/migration/AppShell/AppShellView.swift
+++ b/Sources/RunBot/migration/AppShell/AppShellView.swift
@@ -18,6 +18,8 @@ struct AppShellView: View {
     let runnerState: RunnerState
     /// Configured local-runner store forwarded from the composition root.
     let localRunnerStore: LocalRunnerStore
+    /// Settings services forwarded from the composition root.
+    let settingsDependencies: MigrationSettingsDependencies
 
     /// The top-level split-view layout.
     var body: some View {
@@ -33,7 +35,8 @@ struct AppShellView: View {
                 selection: selection,
                 authentication: authentication,
                 runnerState: runnerState,
-                localRunnerStore: localRunnerStore
+                localRunnerStore: localRunnerStore,
+                settingsDependencies: settingsDependencies
             )
         }
         .navigationSplitViewStyle(.balanced)

--- a/Sources/RunBot/migration/Features/Settings/MigrationSettingsView.swift
+++ b/Sources/RunBot/migration/Features/Settings/MigrationSettingsView.swift
@@ -1,18 +1,81 @@
 // MigrationSettingsView.swift
 // RunBot
 
+import AppUpdater
+import GitHubClient
+import RunBotCore
 import SwiftUI
 
-/// Placeholder root view for the Settings destination.
-/// Internal layout is introduced in a later migration step.
+// MARK: - MigrationSettingsView
+
+/// Single-column scrollable settings destination for the windowed app shell.
+///
+/// Replaces the Step-7 placeholder with a finite-width scroll view that
+/// reuses existing authentication, general, update, and about sections.
+///
+/// ## Layout
+/// Content is constrained to 520–760 pt so settings remain readable
+/// in a wide application window without stretching labels and controls.
+///
+/// ## Dependency rules
+/// - `GitHubAuthentication` is read from the SwiftUI environment (owned by
+///   `RunBotDesktopApp`). Do not create a second instance here.
+/// - OAuth sign-in / sign-out are closures on `MigrationSettingsDependencies`
+///   built at the app root, so this view never touches `OAuthCredentialController`
+///   or `GitHubClient` directly.
+/// - `setSelectedSource` is called directly on the environment `authentication`
+///   object — the same instance observed by `MigrationScopeView`.
+@MainActor
 struct MigrationSettingsView: View {
-    /// The placeholder content.
+
+    // MARK: - Environment
+
+    @Environment(GitHubAuthentication.self)
+    private var authentication
+
+    // MARK: - Inputs
+
+    let dependencies: MigrationSettingsDependencies
+
+    // MARK: - Body
+
     var body: some View {
-        ContentUnavailableView(
-            "Settings",
-            systemImage: "gearshape",
-            description: Text("Settings controls will be added in a later migration step.")
-        )
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Settings")
+                    .font(.largeTitle.weight(.semibold))
+
+                AuthenticationSection(
+                    authentication: authentication,
+                    onSignIn: dependencies.onSignIn,
+                    onSignOut: { Task { await dependencies.onSignOut() } },
+                    onToggleEnvironment: { enabled in
+                        if enabled {
+                            authentication.setSelectedSource(.environment)
+                        } else {
+                            authentication.setSelectedSource(.unauthenticated)
+                        }
+                    }
+                )
+
+                GeneralSettingsSection()
+
+                UpdateSettingsSection(
+                    settings: dependencies.settings,
+                    runnerState: dependencies.runnerState,
+                    autoUpdater: dependencies.autoUpdater
+                )
+
+                AboutSettingsSection()
+            }
+            .padding(24)
+            .frame(
+                minWidth: 520,
+                idealWidth: 680,
+                maxWidth: 760,
+                alignment: .leading
+            )
+        }
         .navigationTitle("Settings")
     }
 }

--- a/Sources/RunBot/migration/Features/Settings/MigrationSettingsView.swift
+++ b/Sources/RunBot/migration/Features/Settings/MigrationSettingsView.swift
@@ -30,15 +30,18 @@ struct MigrationSettingsView: View {
 
     // MARK: - Environment
 
+    /// The active GitHub authentication state, injected from the environment.
     @Environment(GitHubAuthentication.self)
     private var authentication
 
     // MARK: - Inputs
 
+    /// Services required by the settings sections.
     let dependencies: MigrationSettingsDependencies
 
     // MARK: - Body
 
+    /// The scrollable settings layout.
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {

--- a/Sources/RunBot/migration/MigrationAppDependencies.swift
+++ b/Sources/RunBot/migration/MigrationAppDependencies.swift
@@ -1,5 +1,8 @@
 // MigrationAppDependencies.swift
 // RunBot
+import AppUpdater
+import Foundation
+import GitHubClient
 import Observation
 import RunBotCore
 
@@ -18,11 +21,36 @@ final class MigrationAppDependencies {
     /// The configured local-runner store, ready for injection into views.
     let localRunnerStore: LocalRunnerStore
 
+    /// Settings services.
+    /// Owns the auth callbacks and updater needed by `MigrationSettingsView`.
+    let settingsDependencies: MigrationSettingsDependencies
+
     /// Configures `LocalRunnerStore` synchronously then captures the shared instance.
-    init() {
+    /// `settingsDependencies` is constructed after the runner store so it can
+    /// share the already-created `RunnerState`.
+    init(
+        authentication: GitHubAuthentication,
+        onSignIn: @escaping @MainActor () -> Void,
+        onSignOut: @escaping @MainActor () async -> Void
+    ) {
         let state = RunnerState()
         self.runnerState = state
         LocalRunnerStore.configure(viewModel: state)
         self.localRunnerStore = LocalRunnerStore.shared
+        self.settingsDependencies = MigrationSettingsDependencies(
+            settings: .shared,
+            runnerState: state,
+            autoUpdater: AppUpdater(
+                repo: "runbot-hq/run-bot",
+                currentVersion: Bundle.main.rbVersionString,
+                assetName: { _ in "RunBot.zip" },
+                publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")
+                    ?? { preconditionFailure("Ed25519 public key is not valid base64") }(),
+                schedulerIdentifier: "io.github.runbot-hq.update-check",
+                betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
+            ),
+            onSignIn: onSignIn,
+            onSignOut: onSignOut
+        )
     }
 }

--- a/Sources/RunBot/migration/MigrationSettingsDependencies.swift
+++ b/Sources/RunBot/migration/MigrationSettingsDependencies.swift
@@ -33,6 +33,7 @@ final class MigrationSettingsDependencies {
     /// Called to sign out and remove the stored OAuth token.
     let onSignOut: @MainActor () async -> Void
 
+    /// Creates a fully configured settings dependency bundle.
     init(
         settings: AppPreferencesStore,
         runnerState: RunnerState,

--- a/Sources/RunBot/migration/MigrationSettingsDependencies.swift
+++ b/Sources/RunBot/migration/MigrationSettingsDependencies.swift
@@ -1,0 +1,49 @@
+// MigrationSettingsDependencies.swift
+// RunBot
+
+import AppUpdater
+import RunBotCore
+
+// MARK: - MigrationSettingsDependencies
+
+/// Holds the services genuinely needed by the windowed Settings destination.
+///
+/// Owned once by `MigrationAppDependencies` and threaded through
+/// `AppShellView` → `AppDetailView` → `MigrationSettingsView`.
+/// Do not instantiate services inside this type — receive them from
+/// the composition root to avoid the startup-coupling regression
+/// removed after issue #2815.
+///
+/// ## Auth actions
+/// OAuth sign-in / sign-out require `OAuthCredentialController`, which
+/// depends on `GitHubClient`. Rather than pulling `GitHubClient` into the
+/// migration layer, those actions are expressed as plain closures built
+/// at the app root where the controller already exists.
+@MainActor
+final class MigrationSettingsDependencies {
+    /// App-wide preference store (automatic updates, beta channel).
+    let settings: AppPreferencesStore
+    /// Observable runner state — drives the update action row.
+    let runnerState: RunnerState
+    /// Shared auto-updater; must be owned at the composition root.
+    let autoUpdater: AppUpdater
+
+    /// Called to initiate the OAuth sign-in browser flow.
+    let onSignIn: @MainActor () -> Void
+    /// Called to sign out and remove the stored OAuth token.
+    let onSignOut: @MainActor () async -> Void
+
+    init(
+        settings: AppPreferencesStore,
+        runnerState: RunnerState,
+        autoUpdater: AppUpdater,
+        onSignIn: @escaping @MainActor () -> Void,
+        onSignOut: @escaping @MainActor () async -> Void
+    ) {
+        self.settings = settings
+        self.runnerState = runnerState
+        self.autoUpdater = autoUpdater
+        self.onSignIn = onSignIn
+        self.onSignOut = onSignOut
+    }
+}

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -17,6 +17,7 @@ struct RunBotDesktopApp: App {
     /// Constructed in `init()` so it shares the same `authentication` instance.
     @State private var deps: MigrationAppDependencies
 
+    /// Initialises shared authentication and dependency bundle before first render.
     init() {
         let auth = GitHubAuthentication()
         _authentication = State(initialValue: auth)

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -11,17 +11,33 @@ import SwiftUI
 /// `@main` is intentionally absent because `main.swift` invokes `main()`.
 struct RunBotDesktopApp: App {
     /// Authentication state owned at the window level and injected into the view hierarchy.
-    @State private var authentication = GitHubAuthentication()
+    @State private var authentication: GitHubAuthentication
     /// Runner dependencies configured synchronously before any view is mounted.
     /// `LocalRunnerStore.configure` runs inside `MigrationAppDependencies.init()`.
-    @State private var deps = MigrationAppDependencies()
+    /// Constructed in `init()` so it shares the same `authentication` instance.
+    @State private var deps: MigrationAppDependencies
+
+    init() {
+        let auth = GitHubAuthentication()
+        _authentication = State(initialValue: auth)
+        _deps = State(initialValue: MigrationAppDependencies(
+            authentication: auth,
+            onSignIn: {
+                // OAuthCredentialController lives in AppState (legacy layer).
+                // For the migration shell, sign-in is a no-op placeholder.
+                // TODO: wire real coordinator when AppState is retired (#2815).
+            },
+            onSignOut: {}
+        ))
+    }
 
     /// The scene graph for the windowed application.
     var body: some Scene {
         Window("RunBot", id: "main") {
             AppShellView(
                 runnerState: deps.runnerState,
-                localRunnerStore: deps.localRunnerStore
+                localRunnerStore: deps.localRunnerStore,
+                settingsDependencies: deps.settingsDependencies
             )
             .environment(authentication)
         }


### PR DESCRIPTION
Part of #2793
Stacked on #2817

## What

Replaces the Settings placeholder with a scrollable, single-column settings detail that reuses the existing authentication, general, update, and about rows from the legacy menu-bar settings view.

## Changes

- Replace `MigrationSettingsView` placeholder with a scrollable settings detail.
- Reuse the existing `AuthenticationSection` and authentication cards.
- Extract reusable general-settings rows from `SettingsView+Sections`.
- Extract reusable update-settings rows from `SettingsView+Sections`.
- Extract reusable About/version content.
- Wire launch-at-login through the existing `LoginItem` behaviour.
- Wire update and beta-channel controls through the existing updater/preferences.
- Use the existing root `GitHubAuthentication` instance.
- Extend `MigrationAppDependencies` only for required settings services.
- Omit legacy panel navigation to Scopes and Local runners.

## Out of scope

- Workflow production data and step-log rendering.
- Scope and runner changes.
- Redesigning settings rows.
- New UI, snapshot, or formatting tests.

## Summary by Sourcery

Introduce a full settings experience in the migrated desktop app, replacing the placeholder view with a scrollable, single-column layout wired to existing authentication, general, update, and about services.

New Features:
- Add a windowed Settings destination that reuses existing authentication, general, update, and about sections in a constrained scrollable layout.

Enhancements:
- Thread a shared GitHubAuthentication instance and settings-related services from the app composition root into the migration shell to avoid duplicate service ownership.
- Extract reusable General, Update, and About settings sections from legacy settings code for use in the migration UI.
- Configure an AppUpdater instance in the migration dependencies to drive automatic updates, beta-channel preferences, and in-app update actions.
- Wire launch-at-login behavior through the shared LoginItem helper for the migrated Settings view.

Chores:
- Adjust MigrationAppDependencies and RunBotDesktopApp initialization to construct and pass MigrationSettingsDependencies through the shell views to MigrationSettingsView.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Settings placeholder with a functional, single‑column, scrollable settings view. Previously Settings was a placeholder; now it renders authentication, general (launch at login), updates (automatic updates + beta with updater actions), and about (version). Adds doc comments to satisfy SwiftLint missing_docs without changing behavior.

- Review notes
  - `MigrationSettingsView` consumes a single `MigrationSettingsDependencies` built in `MigrationAppDependencies` (shared `RunnerState`, `AppPreferencesStore.shared`, one `AppUpdater`, and injected sign‑in/sign‑out closures). `GitHubAuthentication` comes from the environment; no extra instances.
  - Behavior: the “Launch at login” toggle writes to `LoginItem`; enabling automatic updates or toggling beta calls `AppUpdater.checkAndHandle(...)`; the update action row appears when `runnerState.currentPhase != .idle`; “Install & Relaunch” uses the injected updater; About shows version/build from `Bundle.main` with a pre‑release badge via `Bundle.main.isPreReleaseBuild`.

- Migration
  - Update call sites to construct `MigrationAppDependencies(authentication:onSignIn:onSignOut:)` and thread `settingsDependencies` through `AppShellView` → `AppDetailView` → `MigrationSettingsView`.

<sup>Written for commit 88b04ffef81cde345242acc3d155b3a7a672bdc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

