### PR TITLE
fix: stabilize migrated app environment

### DIFF
--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -25,7 +25,8 @@ struct LocalRunnersView: View {
 
     /// The local runner actor. Used only for mutations (refresh, optimistic updates).
     /// Observed state (`localRunners`, `isLocalScanning`) is read from the `RunnerState`
-    /// environment object injected by `AppDelegate.wrapEnv`.
+    /// environment object injected at the root of both the legacy panel hierarchy
+    /// and the windowed app hierarchy.
     /// Injected by the caller; defaults to `LocalRunnerStore.shared` at the `SettingsView` boundary.
     var localRunnerStore: LocalRunnerStore = .shared
 

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
@@ -61,11 +61,12 @@ struct AddRunnerSheet: View {
     /// Injected local runner store — avoids direct `.shared` references inside the sheet.
     var localRunnerStore: LocalRunnerStore = .shared
     /// Core runner state — read for synchronous duplicate checks against localRunners.
-    /// No default is provided: the value is injected via `AppDelegate.wrapEnv`.
+    /// No default is provided: the value is injected at the root of both the legacy
+    /// panel hierarchy and the windowed app hierarchy.
     @Environment(AppState.self) var appState
     /// Gate that tracks whether any overlay (sheet or file picker) is active.
     /// Used by `pickExistingFolder()` to arm the dismiss gate before opening the picker.
-    /// Injected via `AppDelegate.wrapEnv`.
+    /// Injected at the root of both the legacy panel hierarchy and the windowed app hierarchy.
     @Environment(MBKOverlayGate.self) var overlayGate: MBKOverlayGate
 
     // MARK: - Add Mode

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -51,6 +51,7 @@ struct RunBotDesktopApp: App {
             .environment(authentication)
             .environment(overlayGate)
         }
+        .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1_200, height: 760)
         .windowResizability(.contentMinSize)
     }

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -2,6 +2,7 @@
 // RunBot
 
 import GitHubClient
+import MenuBarKit
 import SwiftUI
 
 // @main removed: Sources/RunBot/main.swift is top-level code.
@@ -16,6 +17,12 @@ struct RunBotDesktopApp: App {
     /// `LocalRunnerStore.configure` runs inside `MigrationAppDependencies.init()`.
     /// Constructed in `init()` so it shares the same `authentication` instance.
     @State private var deps: MigrationAppDependencies
+    /// Single overlay gate for the scene lifetime.
+    ///
+    /// Injected at the root of both the legacy panel hierarchy and the windowed
+    /// app hierarchy. `MBKOverlayGate` is presentation infrastructure; it is not
+    /// placed in `MigrationAppDependencies`.
+    @State private var overlayGate: MBKOverlayGate
 
     /// Initialises shared authentication and dependency bundle before first render.
     init() {
@@ -41,6 +48,7 @@ struct RunBotDesktopApp: App {
                 settingsDependencies: deps.settingsDependencies
             )
             .environment(authentication)
+            .environment(overlayGate)
         }
         .defaultSize(width: 1_200, height: 760)
         .windowResizability(.contentMinSize)

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -37,6 +37,7 @@ struct RunBotDesktopApp: App {
             },
             onSignOut: {}
         ))
+        _overlayGate = State(initialValue: MBKOverlayGate())
     }
 
     /// The scene graph for the windowed application.


### PR DESCRIPTION
Part of #2793
Fixes #2823
Stacked on #2822

## What

Fixes runtime crashes when opening the migrated Scopes and Local runners destinations. The reused MenuBarKit sheet flows require MBKOverlayGate in the SwiftUI environment. The windowed application now owns one gate for the scene lifetime and injects it above the complete app shell.

## Changes

- Add one scene-lifetime MBKOverlayGate to RunBotDesktopApp.
- Inject the gate above AppShellView.
- Preserve the existing shared GitHubAuthentication.
- Preserve MigrationAppDependencies and its construction order.
- Update environment-injection comments that still mentioned only AppDelegate.

## Acceptance criteria

- [ ] RunBot.app launches without an environment assertion.
- [ ] Exactly one MBKOverlayGate is created for the window scene.
- [ ] The gate is injected above AppShellView.
- [ ] Local runners opens without crashing.
- [ ] Add runner opens and closes without crashing.
- [ ] Scopes opens without crashing.
- [ ] Add and edit scope opens and closes without crashing.
- [ ] Settings still uses the existing shared authentication instance.
- [ ] Sidebar metrics continue updating across navigation.
- [ ] No AppState introduced. No second GitHubAuthentication created.
- [ ] swift build passes.
- [ ] swift test passes.
- [ ] SwiftLint passes.
- [ ] build.sh succeeds.

## Summary by Sourcery

Stabilize the migrated desktop app by providing a shared overlay gate in the SwiftUI environment for the window scene and aligning environment-injection comments with the new app shell setup.

Bug Fixes:
- Prevent crashes and environment assertions when opening migrated destinations such as Scopes and Local runners by supplying the required MBKOverlayGate in the app environment.

Enhancements:
- Introduce a single scene-lifetime MBKOverlayGate owned by the windowed application and inject it above the app shell so legacy panels and the windowed UI share the same overlay infrastructure.

Documentation:
- Refresh environment-injection comments to reference the shared root for both legacy panel and windowed app hierarchies instead of the AppDelegate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the migrated windowed app by injecting a scene‑lifetime overlay gate in the SwiftUI environment and hides the window title bar to match the app shell design. Previously, opening Scopes or Local Runners crashed because reused `MenuBarKit` sheet flows required an `MBKOverlayGate`; now one gate per window scene is owned by the app and injected above the app shell.

- Add a scene‑lifetime `overlayGate: MBKOverlayGate` to `RunBotDesktopApp`, initialize it in `init()`, and inject it via `.environment(overlayGate)` around `AppShellView`.
- Set `.windowStyle(.hiddenTitleBar)` for the windowed app; default size and resizability are unchanged.
- Preserve the existing shared authentication and `MigrationAppDependencies` construction order; update comments to reflect root‑level environment injection across legacy panels and the windowed app (no new `AppState`, no second authentication instance).

<sup>Written for commit f44e6b941ffc6edcdf41c0c86f41e41179d303d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

