### PR TITLE
feat: wire live workflow data

### DIFF
--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -25,7 +25,7 @@ struct AppDetailView: View {
     var body: some View {
         switch selection {
         case .workflows:
-            MigrationWorkflowView(workflows: [])
+            MigrationWorkflowView(workflows: runnerState.actions)
         case .localRunners:
             MigrationRunnerView(
                 runnerState: runnerState,

--- a/Sources/RunBot/migration/Features/Workflows/MigrationWorkflowView.swift
+++ b/Sources/RunBot/migration/Features/Workflows/MigrationWorkflowView.swift
@@ -8,7 +8,8 @@ import SwiftUI
 /// Root view for the Workflows destination.
 ///
 /// Owns the four-pane `HSplitView` and the in-memory selection chain.
-/// Production callers pass `workflows: []` until the store is wired in step 5+.
+/// Receives live `[WorkflowActionGroup]` from `RunnerState.actions` via
+/// the composition root. Does not fetch data.
 struct MigrationWorkflowView: View {
 
     /// Workflow data provided by the caller. Empty until production data is wired.

--- a/Sources/RunBot/migration/MigrationAppDependencies.swift
+++ b/Sources/RunBot/migration/MigrationAppDependencies.swift
@@ -13,21 +13,26 @@ import RunBotCore
 /// `LocalRunnerStore.configure(viewModel:)` must be the very first call,
 /// synchronously, before any view is mounted. This mirrors the ordering rule
 /// documented in `AppDelegate+StoreSetup.swift` (fix for issue #1741).
+///
+/// Startup ordering:
+///   LocalRunnerStore.configure    <- synchronous, in init()
+///   oauthCredentials.reconcile    <- sync, in start() before first await
+///   oauthCredentials.start        <- sync, in start() before first await
+///   localRunnerStore.refreshAsync <- first suspension point
+///   runnerStore.start             <- begins poll loop
 @MainActor
 @Observable
 final class MigrationAppDependencies {
-    /// Observable runner state that `LocalRunnerStore` pushes snapshots into.
     let runnerState: RunnerState
-    /// The configured local-runner store, ready for injection into views.
     let localRunnerStore: LocalRunnerStore
-
-    /// Settings services.
-    /// Owns the auth callbacks and updater needed by `MigrationSettingsView`.
     let settingsDependencies: MigrationSettingsDependencies
 
-    /// Configures `LocalRunnerStore` synchronously then captures the shared instance.
-    /// `settingsDependencies` is constructed after the runner store so it can
-    /// share the already-created `RunnerState`.
+    private let authentication: GitHubAuthentication
+    private let github: GitHubClient
+    private let oauthCredentials: OAuthCredentialController
+    private var runnerStore: (any RunnerPollerProtocol)?
+    private var didStart = false
+
     init(
         authentication: GitHubAuthentication,
         onSignIn: @escaping @MainActor () -> Void,
@@ -35,8 +40,53 @@ final class MigrationAppDependencies {
     ) {
         let state = RunnerState()
         self.runnerState = state
+        self.authentication = authentication
+
+        // MUST be synchronous and first (issue #1741).
         LocalRunnerStore.configure(viewModel: state)
         self.localRunnerStore = LocalRunnerStore.shared
+
+        // GitHub client - same configuration as AppState.
+        // WARNING: service/account match the pre-GitHubClient keychain entry name.
+        // Do NOT change - doing so orphans stored tokens and forces re-authentication.
+        let client = GitHubClient(
+            clientID: OAuthSecrets.clientID,
+            clientSecret: OAuthSecrets.clientSecret,
+            service: "run-bot",
+            account: "github-oauth-token",
+            authSource: { authentication.selectedSource },
+            logger: GitHubLoggerAdapter()
+        )
+        self.github = client
+
+        // Poll-loop actor - mirrors AppState.seedStoreAndPoller().
+        let poller = RunnerPoller(
+            state: state,
+            preferencesStore: AppPreferencesStore.shared,
+            scopeStore: ScopeStore.shared,
+            localRunners: { state.localRunners },
+            applyMetrics: { metrics, id, name in
+                await LocalRunnerStore.shared.applyMetrics(
+                    metrics,
+                    forRunnerId: id,
+                    name: name
+                )
+            },
+            notificationPreferences: NotificationPreferences.shared
+        )
+        self.runnerStore = poller
+
+        // Credential controller - same init as AppState.
+        // didSignOut restarts the poll loop after sign-out.
+        let credentials = OAuthCredentialController(
+            service: client.oauthService,
+            authentication: authentication
+        )
+        credentials.didSignOut = { [weak poller] in
+            await poller?.start()
+        }
+        self.oauthCredentials = credentials
+
         self.settingsDependencies = MigrationSettingsDependencies(
             settings: .shared,
             runnerState: state,
@@ -52,5 +102,33 @@ final class MigrationAppDependencies {
             onSignIn: onSignIn,
             onSignOut: onSignOut
         )
+    }
+}
+
+// MARK: - Startup
+
+extension MigrationAppDependencies {
+    /// Starts the domain pipeline: credential reconcile -> local refresh -> poll loop.
+    ///
+    /// Idempotent - SwiftUI may recreate the root .task; subsequent calls are no-ops.
+    ///
+    /// Ordering mirrors the domain subset of AppState.start():
+    ///   1. reconcile + start observations - sync, before first await
+    ///   2. localRunnerStore.refreshAsync  - hydrates local runners
+    ///   3. runnerStore.start              - begins GitHub poll loop
+    func start() async {
+        guard !didStart else { return }
+        didStart = true
+
+        // Step 1 - sync, before first suspension point.
+        oauthCredentials.reconcile()
+        oauthCredentials.start()
+
+        // Step 2 - hydrate local runners before the poll loop fires.
+        await localRunnerStore.refreshAsync()
+
+        // Step 3 - begin GitHub Actions poll loop.
+        guard let store = runnerStore else { return }
+        await store.start()
     }
 }

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -50,6 +50,9 @@ struct RunBotDesktopApp: App {
             )
             .environment(authentication)
             .environment(overlayGate)
+            .task {
+                await deps.start()
+            }
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1_200, height: 760)


### PR DESCRIPTION
## Summary

Wires the full domain pipeline into the windowed app shell so the Workflows view receives live data from the GitHub Actions poll loop instead of a static empty array.

## Changes

- **`MigrationAppDependencies`** — constructs `RunnerPoller`, `OAuthCredentialController`, `GitHubClient`; adds idempotent `start()`
- **`RunBotDesktopApp`** — `.task { await deps.start() }` on the Window scene
- **`AppDetailView`** — `workflows: runnerState.actions` (was `[]`)
- **`MigrationWorkflowView`** — doc-comment updated

## Startup ordering

```
LocalRunnerStore.configure    <- init(), synchronous (issue #1741)
oauthCredentials.reconcile()  <- start(), before first await
oauthCredentials.start()      <- start(), before first await
localRunnerStore.refreshAsync <- first suspension point
runnerStore.start()           <- GitHub poll loop begins
```

## Key decisions

- Keychain entry names unchanged (`service: "run-bot", account: "github-oauth-token"`) — changing orphans stored tokens
- `didSignOut` uses `[weak poller]` capture to restart poll loop, mirroring `AppState`
- Status-item and auto-updater steps excluded — menu-bar concerns not applicable here

Closes #2829

## Summary by Sourcery

Wire the migration app shell to the live domain pipeline so the Workflows view receives real GitHub Actions data driven by the runner poll loop.

New Features:
- Introduce a startup pipeline in MigrationAppDependencies that reconciles credentials, hydrates local runners, and starts the GitHub Actions poll loop.
- Provide MigrationWorkflowView with live workflow action data from RunnerState instead of a static empty list.

Enhancements:
- Construct and manage GitHub authentication, client, credential controller, and runner poller within MigrationAppDependencies with idempotent startup.
- Trigger dependency startup from RunBotDesktopApp using a root .task on the main window scene.
- Clarify MigrationWorkflowView documentation to reflect its role in consuming live workflow data without performing its own fetching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows live GitHub Actions workflows in the migration app shell. Previously the Workflows view received `[]`; now it uses `RunnerState.actions` populated by a poll loop started when the window mounts.

- Introduces `MigrationAppDependencies` that constructs `RunnerPoller`, `OAuthCredentialController`, and `GitHubClient`; adds idempotent `start()` with ordering: reconcile/start credentials -> refresh local runners -> start poller.
- Starts the pipeline via `.task { await deps.start() }` in `RunBotDesktopApp`.
- Updates `AppDetailView` to pass `runnerState.actions` to `MigrationWorkflowView`; the view does not fetch data.
- Keeps keychain identifiers unchanged (service: "run-bot", account: "github-oauth-token") to avoid orphaning tokens.
- On sign-out, restarts the poll loop using a weak-captured poller.
- Closes #2829.

<sup>Written for commit ecc9016de53bad3849eac13464c0f780ba18419a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

