### PR TITLE
fix: match sidebar metrics design

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -142,23 +142,25 @@ extension Color {
     /// Primary accent alias — resolves to `rbBlue`.
     static let rbAccent = rbBlue
 
-    // MARK: Sidebar Metric Tint Tokens
+    // MARK: Sidebar Metric Severity
 
-    /// Fixed tint for the CPU sparkline in the sidebar metrics footer.
-    static let rbMetricCPU = Color.adaptive(
-        light: Color(red: 0.18, green: 0.64, blue: 0.18),
-        dark: Color(red: 0.25, green: 0.80, blue: 0.25)
-    )
-    /// Fixed tint for the GPU sparkline in the sidebar metrics footer.
-    static let rbMetricGPU = Color.adaptive(
-        light: Color(red: 0.0, green: 0.48, blue: 1.0),
-        dark: Color(red: 0.3, green: 0.64, blue: 1.0)
-    )
-    /// Fixed tint for memory and disk capacity bars in the sidebar metrics footer.
-    static let rbMetricCapacity = Color.adaptive(
-        light: Color(red: 0.80, green: 0.55, blue: 0.05),
-        dark: Color(red: 1.0, green: 0.75, blue: 0.20)
-    )
+    /// Returns the severity color for a 0–100 percentage using shared thresholds.
+    ///
+    /// - 0–60 %  → green (`.rbSuccess`)
+    /// - >60–85 % → orange (`.rbWarning`)
+    /// - >85 %    → red (`.rbDanger`)
+    ///
+    /// Used by `SparklineView`, `SidebarUsageMetricView`, and
+    /// `SidebarCapacityMetricView` so threshold logic is defined once.
+    static func rbMetricSeverity(percentage: Double) -> Color {
+        let clamped = min(max(percentage, 0), 100)
+        if clamped > 85 { return .rbDanger }
+        if clamped > 60 { return .rbWarning }
+        return .rbSuccess
+    }
+
+    // MARK: Sidebar Metric Track
+
     /// Neutral track fill for empty sparkline and capacity-bar backgrounds.
     static let rbMetricTrack = Color.secondary.opacity(0.18)
 

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -142,6 +142,26 @@ extension Color {
     /// Primary accent alias — resolves to `rbBlue`.
     static let rbAccent = rbBlue
 
+    // MARK: Sidebar Metric Tint Tokens
+
+    /// Fixed tint for the CPU sparkline in the sidebar metrics footer.
+    static let rbMetricCPU = Color.adaptive(
+        light: Color(red: 0.18, green: 0.64, blue: 0.18),
+        dark: Color(red: 0.25, green: 0.80, blue: 0.25)
+    )
+    /// Fixed tint for the GPU sparkline in the sidebar metrics footer.
+    static let rbMetricGPU = Color.adaptive(
+        light: Color(red: 0.0, green: 0.48, blue: 1.0),
+        dark: Color(red: 0.3, green: 0.64, blue: 1.0)
+    )
+    /// Fixed tint for memory and disk capacity bars in the sidebar metrics footer.
+    static let rbMetricCapacity = Color.adaptive(
+        light: Color(red: 0.80, green: 0.55, blue: 0.05),
+        dark: Color(red: 1.0, green: 0.75, blue: 0.20)
+    )
+    /// Neutral track fill for empty sparkline and capacity-bar backgrounds.
+    static let rbMetricTrack = Color.secondary.opacity(0.18)
+
     // MARK: Surface & Border Tokens
     //
     // DESIGN TOKEN NOTE:

--- a/Sources/RunBot/Views/Components/SparklineView.swift
+++ b/Sources/RunBot/Views/Components/SparklineView.swift
@@ -41,10 +41,10 @@ struct SparklineView: View {
             strokePath(in: size)
                 .stroke(resolvedColor, lineWidth: 1.5)
         }
+    }
 
     /// Resolved color: explicit tint when provided, otherwise threshold-driven color.
     private var resolvedColor: Color { tint ?? themeColor }
-    }
 
     /// Accent color shifting green -> orange -> red as `currentPct` crosses 60 and 85.
     private var themeColor: Color {

--- a/Sources/RunBot/Views/Components/SparklineView.swift
+++ b/Sources/RunBot/Views/Components/SparklineView.swift
@@ -46,11 +46,9 @@ struct SparklineView: View {
     /// Resolved color: explicit tint when provided, otherwise threshold-driven color.
     private var resolvedColor: Color { tint ?? themeColor }
 
-    /// Accent color shifting green -> orange -> red as `currentPct` crosses 60 and 85.
+    /// Accent color derived from the shared severity helper (green/orange/red).
     private var themeColor: Color {
-        if currentPct > 85 { return .rbDanger }
-        if currentPct > 60 { return .rbWarning }
-        return .rbSuccess
+        .rbMetricSeverity(percentage: currentPct)
     }
 
     /// Builds the open polyline `Path` used for the stroke layer.

--- a/Sources/RunBot/Views/Components/SparklineView.swift
+++ b/Sources/RunBot/Views/Components/SparklineView.swift
@@ -12,6 +12,12 @@ struct SparklineView: View {
     let history: [Double]
     /// Current value used to determine the theme color (0-100).
     let currentPct: Double
+    /// Optional fixed tint that overrides the threshold-driven color.
+    ///
+    /// When `nil` (the default) the existing green/orange/red threshold
+    /// behavior is preserved. Sidebar CPU and GPU pass a fixed tint so their
+    /// sparkline color does not shift with load level.
+    var tint: Color?
 
     /// Renders a gradient fill path and a stroke polyline scaled to the available geometry.
     var body: some View {
@@ -27,14 +33,17 @@ struct SparklineView: View {
             fillPath(in: size)
                 .fill(
                     LinearGradient(
-                        colors: [themeColor.opacity(0.85), themeColor.opacity(0.05)],
+                        colors: [resolvedColor.opacity(0.85), resolvedColor.opacity(0.05)],
                         startPoint: .top,
                         endPoint: .bottom
                     )
                 )
             strokePath(in: size)
-                .stroke(themeColor, lineWidth: 1.5)
+                .stroke(resolvedColor, lineWidth: 1.5)
         }
+
+    /// Resolved color: explicit tint when provided, otherwise threshold-driven color.
+    private var resolvedColor: Color { tint ?? themeColor }
     }
 
     /// Accent color shifting green -> orange -> red as `currentPct` crosses 60 and 85.

--- a/Sources/RunBot/migration/AppShell/AppSidebarView.swift
+++ b/Sources/RunBot/migration/AppShell/AppSidebarView.swift
@@ -24,7 +24,6 @@ struct AppSidebarView: View {
             Divider()
 
             SidebarMetricsView()
-                .padding(10)
         }
         .navigationTitle("RunBot")
     }

--- a/Sources/RunBot/migration/AppShell/AppSidebarView.swift
+++ b/Sources/RunBot/migration/AppShell/AppSidebarView.swift
@@ -24,6 +24,8 @@ struct AppSidebarView: View {
             Divider()
 
             SidebarMetricsView()
+                .padding(.horizontal, 10)
+                .padding(.bottom, 10)
         }
         .navigationTitle("RunBot")
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
@@ -5,50 +5,86 @@ import SwiftUI
 
 // MARK: - SidebarCapacityMetricView
 
-/// Compact two-line metric row showing used / total GB and available GB.
+/// Three-zone metric row: header with used/total, capacity progress bar, used/free footer.
 ///
 /// Used for Memory and Disk in the sidebar metrics footer.
-/// Values are expressed in GB (Double) to match `SystemStats` storage;
-/// `formatGB(_:)` trims trailing zeros and appends "GB".
+/// Values are expressed in GB (Double) to match `SystemStats` storage.
+/// Adaptive precision: values below 100 GB show one decimal; 100+ show none.
 struct SidebarCapacityMetricView: View {
 
-    /// Short uppercase label, e.g. "MEM" or "DISK".
+    /// Short uppercase label shown as the row heading, e.g. "MEM" or "DISK".
     let title: String
+    /// Full spoken label used by VoiceOver, e.g. "Memory" or "Disk".
+    let accessibilityTitle: String
     /// Used capacity in gigabytes.
     let used: Double
     /// Total capacity in gigabytes.
     let total: Double
+    /// Progress bar and footer tint (e.g. `.rbMetricCapacity`).
+    let tint: Color
 
-    /// Available capacity derived from inputs; clamped to zero.
-    private var available: Double { max(total - used, 0) }
+    /// Free capacity clamped to zero.
+    private var free: Double { max(total - used, 0) }
 
-    /// Formats a GB value compactly with one decimal place.
-    private func formatGB(_ gb: Double) -> String {
-        String(format: "%.1f GB", gb)
+    /// Filled fraction clamped to 0-1; zero when total is zero.
+    private var fraction: Double {
+        guard total > 0 else { return 0 }
+        return min(max(used / total, 0), 1)
+    }
+
+    /// Adaptive GB string: one decimal below 100, no decimals at 100+.
+    private func formatted(_ value: Double) -> String {
+        value >= 100
+            ? String(format: "%.0f", value)
+            : String(format: "%.1f", value)
     }
 
     /// Full textual description for VoiceOver.
-    private var accessibilityText: String {
-        "\(title), \(formatGB(used)) used, \(formatGB(total)) capacity, \(formatGB(available)) available"
+    private var accessibilityDescription: String {
+        "\(accessibilityTitle), "
+            + "\(formatted(used)) gigabytes used, "
+            + "\(formatted(total)) gigabytes total, "
+            + "\(formatted(free)) gigabytes free"
     }
 
-    /// The compact two-line capacity row.
+    /// Header, capacity bar, and used/free footer.
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(title)
                     .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .tracking(0.5)
+
                 Spacer()
-                Text("\(formatGB(used)) / \(formatGB(total))")
-                    .font(.caption2.monospacedDigit())
+
+                Text("\(formatted(used)) / \(formatted(total)) GB")
+                    .font(.callout.monospacedDigit())
                     .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
-            Text("\(formatGB(available)) available")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.rbMetricTrack)
+
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: geometry.size.width * fraction)
+                }
+            }
+            .frame(height: 6)
+
+            HStack {
+                Text("used \(formatted(used))")
+                Spacer()
+                Text("free \(formatted(free))")
+            }
+            .font(.caption2.monospacedDigit())
+            .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityText)
+        .accessibilityLabel(accessibilityDescription)
     }
 }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
@@ -20,8 +20,6 @@ struct SidebarCapacityMetricView: View {
     let used: Double
     /// Total capacity in gigabytes.
     let total: Double
-    /// Progress bar and footer tint (e.g. `.rbMetricCapacity`).
-    let tint: Color
 
     /// Free capacity clamped to zero.
     private var free: Double { max(total - used, 0) }
@@ -47,6 +45,11 @@ struct SidebarCapacityMetricView: View {
             + "\(formatted(free)) gigabytes free"
     }
 
+    /// Severity color for the capacity bar, driven by used percentage.
+    private var severityColor: Color {
+        .rbMetricSeverity(percentage: fraction * 100)
+    }
+
     /// Header, capacity bar, and used/free footer.
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -70,11 +73,11 @@ struct SidebarCapacityMetricView: View {
                         .fill(Color.rbMetricTrack)
 
                     Capsule()
-                        .fill(tint)
+                        .fill(severityColor)
                         .frame(width: geometry.size.width * fraction)
                 }
             }
-            .frame(height: 6)
+            .frame(height: SidebarMetricLayout.barHeight)
 
             HStack {
                 Text("used \(formatted(used))")
@@ -84,6 +87,7 @@ struct SidebarCapacityMetricView: View {
             .font(.caption2.monospacedDigit())
             .foregroundStyle(.secondary)
         }
+        .frame(height: SidebarMetricLayout.rowHeight, alignment: .top)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
@@ -30,30 +30,44 @@ struct SidebarMetricsView: View {
 
     /// The four metric rows grouped in a compact material surface.
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 10) {
             SidebarUsageMetricView(
                 title: "CPU",
+                accessibilityTitle: "CPU",
                 value: viewModel.stats.cpuPct,
-                history: viewModel.cpuHistory.values
+                history: viewModel.cpuHistory.values,
+                tint: .rbMetricCPU,
+                fractionDigits: 1
             )
             SidebarUsageMetricView(
                 title: "GPU",
+                accessibilityTitle: "GPU",
                 value: viewModel.stats.gpuPct,
-                history: viewModel.gpuHistory.values
+                history: viewModel.gpuHistory.values,
+                tint: .rbMetricGPU,
+                fractionDigits: 0
             )
+
+            Divider()
+
             SidebarCapacityMetricView(
                 title: "MEM",
+                accessibilityTitle: "Memory",
                 used: viewModel.stats.memUsedGB,
-                total: viewModel.stats.memTotalGB
+                total: viewModel.stats.memTotalGB,
+                tint: .rbMetricCapacity
             )
             SidebarCapacityMetricView(
                 title: "DISK",
+                accessibilityTitle: "Disk",
                 used: viewModel.stats.diskUsedGB,
-                total: viewModel.stats.diskTotalGB
+                total: viewModel.stats.diskTotalGB,
+                tint: .rbMetricCapacity
             )
         }
-        .padding(10)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxHeight: 240)
         .onAppear {
             viewModel.start()
         }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
@@ -4,6 +4,19 @@
 import RunBotCore
 import SwiftUI
 
+// MARK: - SidebarMetricLayout
+
+/// Shared layout constants for sidebar metric rows.
+/// Use these instead of hardcoding sizes in individual metric views.
+enum SidebarMetricLayout {
+    /// Fixed total row height for every metric row (usage and capacity).
+    static let rowHeight: CGFloat = 44
+    /// Height of the CPU and GPU sparkline graphs.
+    static let graphHeight: CGFloat = 18
+    /// Height of the Memory and Disk capacity bars.
+    static let barHeight: CGFloat = 5
+}
+
 // MARK: - SidebarMetricsView
 
 /// Pinned sidebar footer showing live CPU, GPU, memory, and disk metrics.
@@ -30,13 +43,12 @@ struct SidebarMetricsView: View {
 
     /// The four metric rows grouped in a compact material surface.
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 8) {
             SidebarUsageMetricView(
                 title: "CPU",
                 accessibilityTitle: "CPU",
                 value: viewModel.stats.cpuPct,
                 history: viewModel.cpuHistory.values,
-                tint: .rbMetricCPU,
                 fractionDigits: 1
             )
             SidebarUsageMetricView(
@@ -44,29 +56,27 @@ struct SidebarMetricsView: View {
                 accessibilityTitle: "GPU",
                 value: viewModel.stats.gpuPct,
                 history: viewModel.gpuHistory.values,
-                tint: .rbMetricGPU,
                 fractionDigits: 0
             )
-
-            Divider()
 
             SidebarCapacityMetricView(
                 title: "MEM",
                 accessibilityTitle: "Memory",
                 used: viewModel.stats.memUsedGB,
-                total: viewModel.stats.memTotalGB,
-                tint: .rbMetricCapacity
+                total: viewModel.stats.memTotalGB
             )
             SidebarCapacityMetricView(
                 title: "DISK",
                 accessibilityTitle: "Disk",
                 used: viewModel.stats.diskUsedGB,
-                total: viewModel.stats.diskTotalGB,
-                tint: .rbMetricCapacity
+                total: viewModel.stats.diskTotalGB
             )
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(12)
+        .background(
+            .thinMaterial,
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
         .frame(maxHeight: 240)
         .onAppear {
             viewModel.start()

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 // MARK: - SidebarUsageMetricView
 
-/// Two-zone metric row: percentage header and full-width tinted sparkline.
+/// Two-zone metric row: percentage header and full-width severity-colored sparkline.
 ///
 /// Used for CPU and GPU in the sidebar metrics footer.
 /// When `value` is `nil` the header shows an em-dash and a neutral
@@ -20,8 +20,6 @@ struct SidebarUsageMetricView: View {
     let value: Double?
     /// Ordered oldest-to-newest history values in the range 0-100.
     let history: [Double]
-    /// Fixed sparkline tint (e.g. `.rbMetricCPU`). Does not shift with load level.
-    let tint: Color
     /// Number of decimal places in the formatted percentage string.
     let fractionDigits: Int
 
@@ -64,17 +62,17 @@ struct SidebarUsageMetricView: View {
             if let pct = clampedValue, !history.isEmpty {
                 SparklineView(
                     history: history,
-                    currentPct: pct,
-                    tint: tint
+                    currentPct: pct
                 )
-                .frame(height: 40)
+                .frame(height: SidebarMetricLayout.graphHeight)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
             } else {
                 RoundedRectangle(cornerRadius: 6)
                     .fill(Color.rbMetricTrack)
-                    .frame(height: 40)
+                    .frame(height: SidebarMetricLayout.graphHeight)
             }
         }
+        .frame(height: SidebarMetricLayout.rowHeight, alignment: .top)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
@@ -5,62 +5,77 @@ import SwiftUI
 
 // MARK: - SidebarUsageMetricView
 
-/// Compact one-line metric row showing a percentage value and sparkline history.
+/// Two-zone metric row: percentage header and full-width tinted sparkline.
 ///
 /// Used for CPU and GPU in the sidebar metrics footer.
-/// The sparkline yields layout space before the numeric label so the value
-/// remains readable even in a narrow sidebar.
-///
-/// When `value` is `nil` (e.g. GPU telemetry unavailable) the label shows
-/// an em-dash and the sparkline is omitted entirely — no fabricated zeros.
+/// When `value` is `nil` the header shows an em-dash and a neutral
+/// empty graph band is rendered without fabricating zero samples.
 struct SidebarUsageMetricView: View {
 
-    /// Short uppercase label shown in a fixed-width leading slot, e.g. "CPU".
+    /// Short uppercase label shown as the row heading, e.g. "CPU".
     let title: String
-    /// Current percentage in the range 0–100, or `nil` when telemetry is absent.
+    /// Full spoken label used by VoiceOver, e.g. "CPU" or "GPU".
+    let accessibilityTitle: String
+    /// Current percentage in the range 0-100, or `nil` when telemetry is absent.
     let value: Double?
-    /// Ordered oldest-to-newest history values in the range 0–100.
+    /// Ordered oldest-to-newest history values in the range 0-100.
     let history: [Double]
+    /// Fixed sparkline tint (e.g. `.rbMetricCPU`). Does not shift with load level.
+    let tint: Color
+    /// Number of decimal places in the formatted percentage string.
+    let fractionDigits: Int
+
+    /// Value clamped to 0-100, or `nil` when unavailable.
+    private var clampedValue: Double? {
+        value.map { min(max($0, 0), 100) }
+    }
 
     /// Formatted percentage string, or an em-dash when unavailable.
     private var formattedValue: String {
-        guard let value else { return "—" }
-        let clamped = min(max(value, 0), 100)
-        return String(format: "%.0f%%", clamped)
+        guard let pct = clampedValue else { return "—" }
+        return pct.formatted(
+            .number.precision(.fractionLength(fractionDigits))
+        ) + "%"
     }
 
     /// Full textual description for VoiceOver.
-    private var accessibilityText: String {
-        guard let value else { return "\(title) unavailable" }
-        let clamped = min(max(value, 0), 100)
-        return "\(title) \(String(format: "%.0f", clamped)) percent"
+    private var accessibilityDescription: String {
+        guard clampedValue != nil else { return "\(accessibilityTitle) unavailable" }
+        return "\(accessibilityTitle), \(formattedValue)"
     }
 
-    /// The compact horizontal metric row.
+    /// Header row plus full-width sparkline (or neutral band when unavailable).
     var body: some View {
-        HStack(spacing: 6) {
-            Text(title)
-                .font(.caption2.weight(.semibold))
-                .frame(width: 30, alignment: .leading)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(title)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .tracking(0.5)
 
-            if value != nil, !history.isEmpty {
-                SparklineView(
-                    history: history,
-                    currentPct: min(max(value ?? 0, 0), 100)
-                )
-                .frame(minWidth: 24, idealWidth: 56, maxWidth: 80)
-                .frame(height: 18)
-                .layoutPriority(0)
-            } else {
-                Spacer(minLength: 0).layoutPriority(0)
+                Spacer()
+
+                Text(formattedValue)
+                    .font(.callout.monospacedDigit())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
 
-            Text(formattedValue)
-                .font(.caption.monospacedDigit())
-                .frame(minWidth: 42, alignment: .trailing)
-                .layoutPriority(1)
+            if let pct = clampedValue, !history.isEmpty {
+                SparklineView(
+                    history: history,
+                    currentPct: pct,
+                    tint: tint
+                )
+                .frame(height: 40)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.rbMetricTrack)
+                    .frame(height: 40)
+            }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityText)
+        .accessibilityLabel(accessibilityDescription)
     }
 }


### PR DESCRIPTION
Part of #2793
Fixes #2828
Fixes #2836
Stacked on #2833

## What

Updates the sidebar metrics footer to match the target design, then refines the card layout per follow-up feedback.

CPU and GPU use a two-zone layout: header + full-width severity-colored sparkline. Memory and disk use a header, capacity bar, and used/free footer. All four rows share equal 44 pt height. A rounded `thinMaterial` card groups the four metrics.

## Changes

### DesignTokens.swift
- Add `Color.rbMetricSeverity(percentage:)` shared helper (green/orange/red thresholds)
- Keep `rbMetricTrack` (neutral fill)
- Remove unused fixed `rbMetricCPU`, `rbMetricGPU`, `rbMetricCapacity` tokens

### SparklineView.swift
- `themeColor` delegates to `rbMetricSeverity` — threshold logic defined once
- Preserve optional `tint` override for non-sidebar call sites

### SidebarUsageMetricView.swift
- Remove fixed `tint: Color` parameter
- Sparkline height: 40 → 18 pt (`SidebarMetricLayout.graphHeight`)
- Row height fixed at 44 pt (`SidebarMetricLayout.rowHeight`)

### SidebarCapacityMetricView.swift
- Remove fixed `tint: Color` parameter
- Bar color driven by `rbMetricSeverity(percentage: fraction * 100)`
- Bar height: 6 → 5 pt (`SidebarMetricLayout.barHeight`)
- Row height fixed at 44 pt

### SidebarMetricsView.swift
- Add `SidebarMetricLayout` enum with shared `rowHeight`, `graphHeight`, `barHeight`
- Restore `thinMaterial` rounded-rectangle card (`cornerRadius: 12`)
- Restore inner padding (`12 pt`)
- Remove `Divider` between GPU and Memory
- Keep 240 pt maximum height

### AppSidebarView.swift
- Restore external card inset (`.padding(.horizontal, 10).padding(.bottom, 10)`)

## Out of scope

- New sampling or history behavior
- Per-runner metrics
- Metrics preferences
- Window restoration
- Legacy deletion
- Native sheet migration
- New UI, snapshot, formatter, or sampling tests

## Acceptance criteria

- [ ] CPU displays a header and full-width sparkline
- [ ] CPU displays one decimal place
- [ ] GPU displays a header and full-width sparkline
- [ ] GPU displays no decimal places
- [ ] Unavailable GPU displays `—`
- [ ] Unavailable GPU does not fabricate zero samples
- [ ] Sparse GPU history aligns correctly at the trailing edge
- [ ] Existing non-sidebar sparklines retain their behavior
- [ ] CPU at 0–60% renders green; >60–85% orange; >85% red
- [ ] GPU at 0–60% renders green; >60–85% orange; >85% red
- [ ] Memory bar at 0–60% renders green; >60–85% orange; >85% red
- [ ] Disk bar at 0–60% renders green; >60–85% orange; >85% red
- [ ] Memory displays `used / total GB` with the unit once
- [ ] Disk displays `used / total GB` with the unit once
- [ ] Capacity fractions are clamped to 0–1
- [ ] Zero capacity renders an empty bar
- [ ] Footer labels show used and free values
- [ ] Values below 100 GB use one decimal
- [ ] Values at or above 100 GB use no decimals
- [ ] VoiceOver says Memory and Disk rather than spelling abbreviations
- [ ] All four rows share equal 44 pt height
- [ ] CPU and GPU sparklines are 18 pt tall
- [ ] Memory and Disk capacity bars are 5 pt tall
- [ ] Metrics are grouped inside a rounded thinMaterial card
- [ ] No divider between GPU and Memory rows
- [ ] Footer height never exceeds 240 pt
- [ ] Navigation remains usable at the 480 pt window minimum
- [ ] Metrics fit at the minimum sidebar width
- [ ] The sampler lifecycle and cadence remain unchanged
- [ ] No new tests are added
- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] SwiftLint passes
- [ ] `build.sh` succeeds