### PR TITLE
fix: restore live workflow hierarchy updates

### DIFF
--- a/Sources/RunBot/migration/AppShell/AppDetailView.swift
+++ b/Sources/RunBot/migration/AppShell/AppDetailView.swift
@@ -27,7 +27,7 @@ struct AppDetailView: View {
     var body: some View {
         switch selection {
         case .workflows:
-            MigrationWorkflowView(workflows: runnerState.actions, logFetcher: $logFetcher)
+            MigrationWorkflowView(runnerState: runnerState, logFetcher: $logFetcher)
         case .localRunners:
             MigrationRunnerView(
                 runnerState: runnerState,

--- a/Sources/RunBot/migration/Features/Workflows/MigrationWorkflowView.swift
+++ b/Sources/RunBot/migration/Features/Workflows/MigrationWorkflowView.swift
@@ -8,17 +8,23 @@ import SwiftUI
 /// Root view for the Workflows destination.
 ///
 /// Owns the four-pane `HSplitView` and the in-memory selection chain.
-/// Receives live `[WorkflowActionGroup]` from `RunnerState.actions` via
-/// the composition root. Does not fetch data.
+/// Observes `RunnerState` directly so each poll snapshot updates all three
+/// hierarchy columns in place without a selection reset.
+@MainActor
 struct MigrationWorkflowView: View {
 
-    /// Workflow data provided by the caller. Empty until production data is wired.
-    let workflows: [WorkflowActionGroup]
+    /// Observable runner state. Observed directly to stay live across polls.
+    @Bindable var runnerState: RunnerState
     /// Shared log fetcher threaded from the composition root.
     @Binding var logFetcher: LogFetcher
 
     /// In-memory selection state for the three-level hierarchy.
     @State private var selection = MigrationWorkflowSelection()
+
+    // MARK: - Derived data
+
+    /// Current workflow snapshot derived from the observable runner state.
+    private var workflows: [WorkflowActionGroup] { runnerState.actions }
 
     // MARK: - Derived selection
 
@@ -66,6 +72,9 @@ struct MigrationWorkflowView: View {
                 logFetcher: $logFetcher
             )
             .frame(minWidth: 260, idealWidth: 380, maxWidth: 800)
+        }
+        .onChange(of: runnerState.actions) { _, actions in
+            selection.reconcile(workflows: actions)
         }
     }
 }

--- a/Sources/RunBot/migration/Features/Workflows/Rows/MigrationWorkflowRow.swift
+++ b/Sources/RunBot/migration/Features/Workflows/Rows/MigrationWorkflowRow.swift
@@ -30,7 +30,7 @@ struct MigrationWorkflowRow: View {
     /// The row layout.
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
-            MigrationStatusIndicator(status: workflow.groupStatus.rbStatus)
+            MigrationStatusIndicator(status: workflow.rbStatus)
                 .padding(.top, 4)
 
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -39,12 +39,48 @@ extension GroupStatus {
 /// RBStatus bridging for `GroupStatus`.
 extension GroupStatus {
     /// Maps `GroupStatus` to the shared `RBStatus` for indicator display.
+    /// For completed groups use `WorkflowActionGroup.rbStatus` to get the
+    /// conclusion-aware mapping.
     public var rbStatus: RBStatus {
         switch self {
         case .inProgress: return .inProgress
         case .loading:    return .queued
         case .queued:     return .queued
         case .completed:  return .unknown
+        }
+    }
+}
+
+// MARK: - WorkflowActionGroup + RBStatus
+
+// swiftlint:disable:next missing_docs
+extension WorkflowActionGroup {
+    /// Canonical `RBStatus` derived from both the group's status and its conclusion.
+    ///
+    /// Mirrors the legacy `ActionRowView.rowStatus` mapping so the windowed app
+    /// and the status-bar app show identical conclusion colours.
+    public var rbStatus: RBStatus {
+        switch groupStatus {
+        case .inProgress: return .inProgress
+        case .loading:    return .queued
+        case .queued:     return .queued
+        case .completed:  return completedRBStatus
+        }
+    }
+
+    /// Conclusion-aware status for completed workflow groups.
+    private var completedRBStatus: RBStatus {
+        switch conclusion {
+        case .success:
+            return .success
+        case .failure, .timedOut, .actionRequired, .startupFailure:
+            return .failed
+        case .cancelled:
+            return .cancelled
+        case .skipped:
+            return .skipped
+        case .neutral, .stale, .unknown, nil:
+            return .unknown
         }
     }
 }


### PR DESCRIPTION
Part of #2793
Stacked on #2839

## What

Restores live workflow hierarchy rendering in the windowed app.

Workflow status dots now use the same conclusion-aware mapping as the legacy
status-bar app. The workflow feature observes `RunnerState` directly so new
poll snapshots update the Workflow, Job, and Step columns in place.

## Changes

- Extract the legacy workflow-group status mapping into a reusable
  `WorkflowActionGroup.rbStatus` with `completedRBStatus` helper.
- Add `// swiftlint:disable:next missing_docs` to suppress the extension-level
  docs warning (extensions without an explicit access level are internal).
- Use `workflow.rbStatus` in `MigrationWorkflowRow` instead of
  `workflow.groupStatus.rbStatus`.
- Pass observable `RunnerState` into `MigrationWorkflowView` via `@Bindable`.
- Read `runnerState.actions` directly as a derived computed property — not copied
  into `@State`.
- Derive selected workflow, job, and step from the latest snapshot.
- Reconcile selection via `.onChange(of: runnerState.actions)`.
- Update `AppDetailView` callsite: pass `runnerState` not `runnerState.actions`.

## Out of scope

- Polling cadence or API changes.
- Workflow row visual redesign.
- Step Log redesign.
- Window or selection restoration.
- Legacy menu-bar removal.
- New UI, snapshot, or formatting tests.
- Per-row timers.

## Acceptance criteria

- [ ] Successful workflow groups display a green status indicator.
- [ ] Failed workflow groups display a red status indicator.
- [ ] In-progress workflow groups display the existing active status color.
- [ ] Queued/loading workflow groups display the existing queued status color.
- [ ] Unknown conclusions remain neutral rather than incorrectly green or red.
- [ ] Legacy and migrated workflow rows use the same status mapping.
- [ ] `MigrationWorkflowView` observes the existing `RunnerState`.
- [ ] `runnerState.actions` is not copied into local `@State`.
- [ ] Workflow rows update after every published polling snapshot.
- [ ] The selected workflow's jobs update live.
- [ ] The selected job's steps update live.
- [ ] Job and step progress update without reselecting rows.
- [ ] Valid workflow/job/step selection survives refreshes.
- [ ] Removed workflows clear the full selection chain.
- [ ] Removed jobs clear job and step selection only.
- [ ] Removed steps clear step selection only.
- [ ] Status transitions do not destroy list-row identity.
- [ ] Step Log selection remains stable across status refreshes.
- [ ] No second RunnerState, poller, or workflow collection is introduced.
- [ ] Polling cadence remains unchanged.
- [ ] No new tests are added.
- [ ] `swift build` passes.
- [ ] `swift test` passes.
- [ ] SwiftLint passes.
- [ ] `build.sh` succeeds.

## Summary by Sourcery

Restore live workflow hierarchy updates in the migrated windowed app and align workflow status indicators with the legacy status-bar behavior.

New Features:
- Expose a conclusion-aware RBStatus mapping on WorkflowActionGroup for consistent workflow status indicators across apps.

Enhancements:
- Make MigrationWorkflowView observe RunnerState directly and derive workflows and selection from the latest actions snapshot so workflow, job, and step columns update in place.
- Update migration workflow rows to use the new workflow-level RBStatus mapping and reconcile selection when runner actions change.
- Adjust AppDetailView to pass RunnerState into MigrationWorkflowView instead of a copied actions array.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores live workflow hierarchy updates by observing RunnerState and aligning status indicators with the legacy mapping. Previously the view used a copied actions array and could miscolor completed workflows; now it updates in place on each poll with conclusion‑aware statuses.

**Review notes**
- Share status mapping via WorkflowActionGroup.rbStatus (with completedRBStatus) and use it in MigrationWorkflowRow to match the legacy status-bar app.
- Observe RunnerState directly in MigrationWorkflowView, derive workflows from runnerState.actions, and reconcile selection on change; update AppDetailView to pass runnerState.
- Migration action: Callers must pass runnerState (not runnerState.actions) to MigrationWorkflowView.
- No polling cadence or API changes; add a SwiftLint suppression for extension-level docs.

<sup>Written for commit b7e476296742c73750a87b77acaca035beed4fdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

