### PR TITLE
fix: workflow status dot never turns green/red on conclusion (blue-to-green)

### DIFF
--- a/Sources/RunBot/migration/Features/Workflows/Columns/MigrationStepLogView.swift
+++ b/Sources/RunBot/migration/Features/Workflows/Columns/MigrationStepLogView.swift
@@ -5,6 +5,14 @@ import GitHubClient
 import RunBotCore
 import SwiftUI
 
+/// Composite identity used to reset `StepLogContentView` state when the
+/// selected job/step pair changes. Step numbers repeat across jobs, so
+/// both values are required.
+private struct StepLogSelectionID: Hashable, Sendable {
+    let jobID: Int
+    let stepNumber: Int
+}
+
 /// Step-log pane — renders the full step log using the shared `StepLogContentView`.
 struct MigrationStepLogView: View {
     /// The job that owns the selected step.
@@ -23,6 +31,7 @@ struct MigrationStepLogView: View {
                     step: step,
                     logFetcher: $logFetcher
                 )
+                .id(StepLogSelectionID(jobID: job.id, stepNumber: step.number))
             } else {
                 MigrationColumnPlaceholder(
                     title: "Select a step",

--- a/Sources/RunBot/migration/Features/Workflows/Columns/MigrationStepLogView.swift
+++ b/Sources/RunBot/migration/Features/Workflows/Columns/MigrationStepLogView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 /// selected job/step pair changes. Step numbers repeat across jobs, so
 /// both values are required.
 private struct StepLogSelectionID: Hashable, Sendable {
+    /// The GitHub Actions job ID that owns the selected step.
     let jobID: Int
+    /// The step number within the job (1-based, as returned by the GitHub API).
     let stepNumber: Int
 }
 

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -90,7 +90,7 @@ extension WorkflowActionGroup {
 ///
 /// Holds only the data needed for display and job fetching — deliberately
 /// minimal so the full job list lives on the parent `WorkflowActionGroup` instead.
-public struct WorkflowRunRef: Identifiable, Sendable {
+public struct WorkflowRunRef: Identifiable, Equatable, Sendable {
     /// The unique GitHub run ID.
     public let id: Int
     /// Workflow file name, e.g. `"SonarQube"`, `"vitest"`.
@@ -210,19 +210,26 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
 
     // MARK: Equatable
 
-    /// Identity-based equality: two groups are equal when their stable `id` matches.
-    ///
-    /// This satisfies the `onChange(of: store.actions)` requirement in `PanelMainView`
-    /// without deep-comparing mutable job arrays on every poll.
-    ///
-    /// ⚠️ `copying()` can produce structurally different instances — for example,
-    /// toggling `isDimmed` or updating `lastJobCompletedAt` — that this operator
-    /// still treats as equal because only `id` is compared. Any caller that needs
-    /// to detect snapshot-level field changes (e.g. freeze-state transitions) must
-    /// compare fields directly; `==` will not fire for those differences.
-    public static func == (lhs: WorkflowActionGroup, rhs: WorkflowActionGroup) -> Bool {
-        lhs.id == rhs.id
-    }
+    // Equality is SYNTHESIZED (memberwise) — deliberately no custom `==`.
+    //
+    // ⚠️ Do NOT reintroduce identity-based (`lhs.id == rhs.id`) equality here.
+    // SwiftUI decides whether to re-invoke a view's `body` by comparing the view's
+    // stored properties with `==`. The migration shell rows and columns
+    // (`MigrationWorkflowRow`, `MigrationWorkflowListView`) store a
+    // `WorkflowActionGroup` / `[WorkflowActionGroup]` directly, so an id-only `==`
+    // made every post-conclusion snapshot compare "equal" and SwiftUI skipped the
+    // re-render — the status dot stayed blue until the view was recreated by
+    // navigating away and back (#2859, #2870).
+    //
+    // Memberwise equality covers `runs`, `jobs`, and `isDimmed`, which are exactly
+    // the inputs of the derived `groupStatus` / `conclusion` / `rbStatus`, so any
+    // status or conclusion change now invalidates the observing views in place.
+    // `id` remains stable across polls, so `List`/`ForEach` still diff groups as
+    // in-place updates rather than remove+insert pairs (#2688 stays fixed).
+    //
+    // Cost note: `onChange(of: store.actions)` in `PanelMainView` now deep-compares
+    // job arrays once per poll snapshot. The lists involved are tens of value
+    // structs — negligible next to the network fetch that produced them.
 
     /// Returns a copy of this group with a replacement jobs array.
     ///


### PR DESCRIPTION
Fixes #2859. Context: #2870.

## Root cause

The blue dot never turning green was not a data, event, or poll-loop problem — the poller updates `RunnerState.actions` on every cycle and `MigrationWorkflowView` observes it correctly. The blocker was **SwiftUI's render-skipping heuristic**:

- SwiftUI decides whether to re-invoke a view's `body` by comparing the view's stored properties with `==`.
- `MigrationWorkflowListView` stores `[WorkflowActionGroup]` and `MigrationWorkflowRow` stores a `WorkflowActionGroup`.
- `WorkflowActionGroup` had a custom **identity-based `==`** (`lhs.id == rhs.id`). Since `id` is deliberately stable across polls, every post-conclusion snapshot compared *equal* to the stale one, so SwiftUI skipped both the list body and the row bodies. The dot stayed blue forever.
- Navigating Settings → Workflows recreated the views from scratch, which is exactly why the correct color appeared after a round-trip but never live.
- The legacy panel on `main` never hit this because `ActionRowView` takes a `tick: Int` that changes every poll and forces the field-wise comparison to fail. The migration rows have no tick, so they relied entirely on `WorkflowActionGroup`'s (broken-for-this-purpose) equality.

This also explains why the 14 previous attempts (poll-loop ownership, vanished-group resolution, AppState sharing, terminality refinements) moved nothing: they all changed how the data updates, not how SwiftUI decides to re-render from it.

## Fix

- Remove the custom `==` from `WorkflowActionGroup` → Swift synthesizes memberwise equality over `runs`, `jobs`, `isDimmed`, etc. — exactly the inputs of the derived `groupStatus` / `conclusion` / `rbStatus`. A concluded run now produces an *unequal* value, so the workflow column and rows re-render in place and blue goes green (or red).
- Add `Equatable` to `WorkflowRunRef` (required for the synthesis; trivially memberwise).
- `id` is untouched and stays stable, so `List` still diffs groups as in-place updates — the #2688 duplicate-row fix is unaffected.

## Blast radius

- `Sources` has exactly two `==` consumers of `actions`: `PanelMainView.onChange` (remeasure/visibleCount) and `MigrationWorkflowView.onChange` (selection reconcile). Both now fire on content changes as well as membership changes, which is more correct for both; cost is a value-struct array compare per poll snapshot — negligible.
- `WorkflowActionGroup` is not `Hashable`; no `Set`/`Dictionary` keying or `firstIndex(of:)` usage exists.
- No test asserts group-to-group equality (they compare derived properties), so semantics of the 350+ existing tests are unchanged. Per #2870, **no new tests added** — this is a one-file production change.

The jobs and steps columns already used full value equality (`ActiveJob`, `GitHubStep`), so with the list no longer being skipped upstream, all three hierarchy columns now refresh live from the same snapshot.

## Summary by Sourcery

Switch workflow status rendering to rely on memberwise equality so SwiftUI correctly re-renders workflow rows when runs conclude.

Bug Fixes:
- Ensure migration workflow status dots update from blue to green/red in place when a workflow run concludes.

Enhancements:
- Have WorkflowActionGroup use synthesized memberwise Equatable conformance instead of custom id-only equality to reflect content changes.
- Make WorkflowRunRef Equatable to support memberwise equality for workflow action groups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workflow status dot staying blue after a run concludes and resets the step log when the selected job/step changes. The dot now turns green/red immediately; the step log reloads instead of persisting stale content.

- Switch `WorkflowActionGroup` to synthesized memberwise `Equatable` and make `WorkflowRunRef` `Equatable` so SwiftUI re-renders on status/conclusion changes.
- Preserve stable `id` for list diffing; the duplicate-row fix remains intact.
- `PanelMainView.onChange` and `MigrationWorkflowView.onChange` now fire on content changes; cost is one value-struct array compare per poll.
- In `MigrationStepLogView`, assign a composite `.id` (`StepLogSelectionID(jobID: job.id, stepNumber: step.number)`) so `StepLogContentView` resets when switching jobs or steps.
- Add missing doc comments to `StepLogSelectionID` properties to satisfy `swiftlint` (no behavior change).

<sup>Written for commit 8084a473563121a6e20d11dd53ccd3dd9aaba227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

