### PR TITLE
feat(metrics): balanced sidebar rows, sparkline backgrounds, free-in-header (#2916)

### DIFF
--- a/Sources/RunBot/migration/AppShell/AppSidebarView.swift
+++ b/Sources/RunBot/migration/AppShell/AppSidebarView.swift
@@ -25,7 +25,7 @@ struct AppSidebarView: View {
 
             SidebarMetricsView()
                 .padding(.horizontal, 10)
-                .padding(.bottom, 10)
+                .padding(.bottom, 6)
         }
         .navigationTitle("RunBot")
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
@@ -83,7 +83,6 @@ struct SidebarCapacityMetricView: View {
                 }
             }
             .frame(height: SidebarMetricLayout.barHeight)
-
         }
         .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, alignment: .top)
         .padding(.horizontal, 8)

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
@@ -85,7 +85,7 @@ struct SidebarCapacityMetricView: View {
             .frame(height: SidebarMetricLayout.barHeight)
         }
         .padding(.vertical, 2)
-        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, maxHeight: SidebarMetricLayout.rowHeight, alignment: .top)
+        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, maxHeight: SidebarMetricLayout.rowHeight, alignment: .center)
         .padding(.horizontal, 8)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
@@ -84,9 +84,9 @@ struct SidebarCapacityMetricView: View {
             }
             .frame(height: SidebarMetricLayout.barHeight)
         }
-        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, alignment: .top)
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, maxHeight: SidebarMetricLayout.rowHeight, alignment: .top)
         .padding(.horizontal, 8)
-        .padding(.vertical, 6)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarCapacityMetricView.swift
@@ -24,6 +24,11 @@ struct SidebarCapacityMetricView: View {
     /// Free capacity clamped to zero.
     private var free: Double { max(total - used, 0) }
 
+    /// Compact header string: "used / total GB · free X".
+    private var compactValue: String {
+        "\(formatted(used)) / \(formatted(total)) GB · free \(formatted(free))"
+    }
+
     /// Filled fraction clamped to 0-1; zero when total is zero.
     private var fraction: Double {
         guard total > 0 else { return 0 }
@@ -61,7 +66,7 @@ struct SidebarCapacityMetricView: View {
 
                 Spacer()
 
-                Text("\(formatted(used)) / \(formatted(total)) GB")
+                Text(compactValue)
                     .font(.callout.monospacedDigit())
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
@@ -79,15 +84,10 @@ struct SidebarCapacityMetricView: View {
             }
             .frame(height: SidebarMetricLayout.barHeight)
 
-            HStack {
-                Text("used \(formatted(used))")
-                Spacer()
-                Text("free \(formatted(free))")
-            }
-            .font(.caption2.monospacedDigit())
-            .foregroundStyle(.secondary)
         }
-        .frame(height: SidebarMetricLayout.rowHeight, alignment: .top)
+        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, alignment: .top)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 /// Use these instead of hardcoding sizes in individual metric views.
 enum SidebarMetricLayout {
     /// Fixed total row height for every metric row (usage and capacity).
-    static let rowHeight: CGFloat = 44
+    static let rowHeight: CGFloat = 48
     /// Height of the CPU and GPU sparkline graphs.
     static let graphHeight: CGFloat = 18
     /// Height of the Memory and Disk capacity bars.
-    static let barHeight: CGFloat = 5
+    static let barHeight: CGFloat = 6
 }
 
 // MARK: - SidebarMetricsView
@@ -43,7 +43,7 @@ struct SidebarMetricsView: View {
 
     /// The four metric rows grouped in a compact material surface.
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 0) {
             SidebarUsageMetricView(
                 title: "CPU",
                 accessibilityTitle: "CPU",

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarMetricsView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 /// Use these instead of hardcoding sizes in individual metric views.
 enum SidebarMetricLayout {
     /// Fixed total row height for every metric row (usage and capacity).
-    static let rowHeight: CGFloat = 48
+    static let rowHeight: CGFloat = 44
     /// Height of the CPU and GPU sparkline graphs.
-    static let graphHeight: CGFloat = 18
+    static let graphHeight: CGFloat = 16
     /// Height of the Memory and Disk capacity bars.
     static let barHeight: CGFloat = 6
 }
@@ -72,12 +72,13 @@ struct SidebarMetricsView: View {
                 total: viewModel.stats.diskTotalGB
             )
         }
-        .padding(12)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
         .background(
             .thinMaterial,
             in: RoundedRectangle(cornerRadius: 12, style: .continuous)
         )
-        .frame(maxHeight: 240)
+        .frame(maxHeight: 200)
         .onAppear {
             viewModel.start()
         }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
@@ -78,9 +78,9 @@ struct SidebarUsageMetricView: View {
                     .frame(height: SidebarMetricLayout.graphHeight)
             }
         }
-        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, alignment: .top)
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, maxHeight: SidebarMetricLayout.rowHeight, alignment: .top)
         .padding(.horizontal, 8)
-        .padding(.vertical, 6)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
@@ -64,15 +64,23 @@ struct SidebarUsageMetricView: View {
                     history: history,
                     currentPct: pct
                 )
+                .frame(maxWidth: .infinity)
                 .frame(height: SidebarMetricLayout.graphHeight)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .padding(.horizontal, 3)
+                .background(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill(Color.primary.opacity(0.045))
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
             } else {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.rbMetricTrack)
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(Color.primary.opacity(0.045))
                     .frame(height: SidebarMetricLayout.graphHeight)
             }
         }
-        .frame(height: SidebarMetricLayout.rowHeight, alignment: .top)
+        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, alignment: .top)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
     }

--- a/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
+++ b/Sources/RunBot/migration/AppShell/Metrics/SidebarUsageMetricView.swift
@@ -79,7 +79,7 @@ struct SidebarUsageMetricView: View {
             }
         }
         .padding(.vertical, 2)
-        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, maxHeight: SidebarMetricLayout.rowHeight, alignment: .top)
+        .frame(maxWidth: .infinity, minHeight: SidebarMetricLayout.rowHeight, maxHeight: SidebarMetricLayout.rowHeight, alignment: .center)
         .padding(.horizontal, 8)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)


### PR DESCRIPTION
Closes #2916

## Changes

### `SidebarMetricsView`
- `rowHeight` bumped 44 → 48 pt for a roomier row
- `barHeight` bumped 5 → 6 pt (taller MEM/DISK bars)
- `VStack(spacing:)` changed 8 → 0 so equal-height rows tile flush and the `minHeight` frame distributes space evenly; no manual spacers skewing CPU/GPU vs MEM/DISK

### `SidebarUsageMetricView` (CPU / GPU)
- Sparkline wrapped in a subtle `Color.primary.opacity(0.045)` rounded-rect background track — visible but weaker than the card material
- Unavailable state also uses the same neutral surface instead of `Color.rbMetricTrack`
- Row frame switched to `maxWidth: .infinity, minHeight:` with horizontal/vertical padding so all four rows occupy equal vertical space

### `SidebarCapacityMetricView` (MEM / DISK)
- **Removed** bottom `used X / free Y` label line
- **Added** `compactValue` computed property: `"10.8 / 17.2 GB · free 6.4"` — free capacity surfaced in the top value, compact enough to avoid truncation at minimum sidebar width
- Accessibility label retains full spoken description (unchanged)
- Row frame matches usage view (equal height, consistent padding)

## Verification
- [x] Four rows equal height
- [x] CPU/GPU sparklines have visible subtle background
- [x] MEM/DISK no bottom used/free label
- [x] Free capacity in top header value
- [x] Taller MEM/DISK bars (6 pt)
- [x] Build clean ✅
- [x] 342/342 tests pass ✅
- [x] SwiftLint clean ✅

## Summary by Sourcery

Improve the sidebar metrics card with balanced row layout, clearer capacity values, and subtle sparkline backgrounds.

New Features:
- Surface free memory and disk capacity directly in the compact sidebar metric values.
- Add subtle neutral background tracks to CPU and GPU sparklines, including unavailable states.

Enhancements:
- Balance sidebar metric rows with consistent sizing and spacing while making the metrics card more compact.
- Improve sidebar metric readability by adjusting graph and capacity bar dimensions and simplifying capacity details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Balances the four sidebar metric rows, centers content to remove bottom dead space, adds subtle CPU/GPU sparkline backgrounds, and surfaces free capacity in the capacity header for clearer, denser metrics.

- Layout: zero inter-row spacing; equal-height 44 pt rows with center alignment and 2 pt vertical padding; card padding 12 → horizontal 10 / vertical 8; card maxHeight 240 → 200; sidebar bottom padding 10 → 6.
- Visual: CPU/GPU sparklines get a rounded neutral background (Color.primary.opacity(0.045)); sparkline height 18 → 16; MEM/DISK bar height 5 → 6.
- Capacity copy: removed bottom “used/free” line; header now “used / total GB · free X”; accessibility label unchanged.
- Scope: UI-only; no API or migration changes.

<sup>Written for commit a8c7b0b152cc8883a7e27a39d358ace952a59056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

