### PR TITLE
fix: resolve Sonar S1186/S2699 code smells across repo (#2956)

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubAPICallCounter.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubAPICallCounter.swift
@@ -50,7 +50,9 @@ public actor APICallCounter: APICallCounterProtocol {
     ///   filter, and produces incorrect results if the buffer is unsorted.
     var timestamps: [ContinuousClock.Instant] = []
     /// Creates a new `APICallCounter` instance.
-    public init() {}
+    public init() {
+        // Intentionally empty: actor holds no state requiring initialisation.
+    }
 
     // MARK: - Protocol
 

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/NullEnvTokenProvider.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/NullEnvTokenProvider.swift
@@ -51,5 +51,7 @@ struct NullEnvTokenProvider: EnvTokenProviding, Sendable {
     /// Always returns `nil` — no env-var read or shell subprocess is performed.
     func token() async -> String? { nil }
     /// No-op — there is no shell outcome latch or cached state to reset.
-    nonisolated func invalidate() {}
+    nonisolated func invalidate() {
+        // Intentionally empty: null-object pattern has no state to reset.
+    }
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubLogger.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubLogger.swift
@@ -21,7 +21,7 @@ public struct SilentGitHubLogger: GitHubLogger {
         // Intentionally empty: stateless no-op logger needs no initialisation.
     }
     /// Does nothing.
-    public nonisolated func log(_ message: String, category: String) {
+    public nonisolated func log(_ _: String, category _: String) {
         // Intentionally empty: default no-op logging implementation.
     }
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubLogger.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubLogger.swift
@@ -17,7 +17,11 @@ public protocol GitHubLogger: Sendable {
 /// A no-op logger used as a safe default when no logger is injected.
 public struct SilentGitHubLogger: GitHubLogger {
     /// Creates a new silent logger.
-    public init() {}
+    public init() {
+        // Intentionally empty: stateless no-op logger needs no initialisation.
+    }
     /// Does nothing.
-    public nonisolated func log(_ message: String, category: String) {}
+    public nonisolated func log(_ message: String, category: String) {
+        // Intentionally empty: default no-op logging implementation.
+    }
 }

--- a/Packages/GitHubClient/Sources/OAuthTokenKit/TokenStore.swift
+++ b/Packages/GitHubClient/Sources/OAuthTokenKit/TokenStore.swift
@@ -74,7 +74,9 @@ public protocol TokenStore: Sendable {
 /// can construct it without a test-target dependency.
 public struct NullTokenStore: TokenStore, Sendable {
     /// Creates a new `NullTokenStore`.
-    public init() {}
+    public init() {
+        // Intentionally empty: stateless null-object store needs no initialisation.
+    }
     /// Always returns `nil` — no token is stored.
     /// `nonisolated` is required by the `TokenStore` protocol: `TokenCache` stores
     /// `any TokenStore` as a `let` property on a `Sendable` type and calls these

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -428,7 +428,9 @@ final class GitHubTransportConcurrencyGateTests {
     }
 
     /// Stops loading (no-op for stubs).
-    override func stopLoading() {}
+    override func stopLoading() {
+      // Intentionally empty: stubbed URL protocol has no real load to stop.
+    }
   }
 
   /// Verifies that when `GitHubTransport` is configured with

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -414,12 +414,14 @@ final class GitHubTransportConcurrencyGateTests {
           try? await Task.sleep(for: storedDelay)
         }
 
-        let response = HTTPURLResponse(
-          url: request.url!,
-          statusCode: 200,
-          httpVersion: "HTTP/1.1",
-          headerFields: ["Content-Type": "application/json"]
-        )!
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+              )
+        else { return }
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
         client?.urlProtocolDidFinishLoading(self)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -419,7 +419,10 @@ final class GitHubTransportConcurrencyGateTests {
                 url: request.url,
                 statusCode: 200,
                 headerFields: ["Content-Type": "application/json"])
-        else { return }
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
         client?.urlProtocolDidFinishLoading(self)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -414,13 +414,11 @@ final class GitHubTransportConcurrencyGateTests {
           try? await Task.sleep(for: storedDelay)
         }
 
-        guard let url = request.url,
-              let response = HTTPURLResponse(
-                url: url,
+        guard
+            let response = makeStubResponse(
+                url: request.url,
                 statusCode: 200,
-                httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
-              )
+                headerFields: ["Content-Type": "application/json"])
         else { return }
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -414,18 +414,10 @@ final class GitHubTransportConcurrencyGateTests {
           try? await Task.sleep(for: storedDelay)
         }
 
-        guard
-            let response = makeStubResponse(
-                url: request.url,
-                statusCode: 200,
-                headerFields: ["Content-Type": "application/json"])
-        else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: data)
-        client?.urlProtocolDidFinishLoading(self)
+        deliverStubbedResponse(
+            data: data,
+            statusCode: 200,
+            headerFields: ["Content-Type": "application/json"])
         await Self.monitor.decrement()
       }
     }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTokenCacheTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTokenCacheTests.swift
@@ -77,7 +77,9 @@ private final class EnvReadingStubProvider: EnvTokenProviding, Sendable {
     }
     return nil
   }
-  func invalidate() {}
+  func invalidate() {
+    // Intentionally empty: test stub has no cached state to reset.
+  }
 }
 
 // MARK: - GitHubTokenCacheTests

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportPaginatedTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportPaginatedTests.swift
@@ -93,7 +93,9 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)
   }
-  override func stopLoading() {}
+  override func stopLoading() {
+    // Intentionally empty: stubbed URL protocol has no real load to stop.
+  }
 }
 
 // MARK: - Helpers

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -84,11 +84,10 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
       return
     }
-    guard let url = request.url,
-          let response = HTTPURLResponse(
-            url: url,
+    guard
+        let response = makeStubResponse(
+            url: request.url,
             statusCode: stub.statusCode,
-            httpVersion: "HTTP/1.1",
             headerFields: stub.headers)
     else { return }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -84,11 +84,13 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
       return
     }
-    let response = HTTPURLResponse(
-      url: request.url!,
-      statusCode: stub.statusCode,
-      httpVersion: "HTTP/1.1",
-      headerFields: stub.headers)!
+    guard let url = request.url,
+          let response = HTTPURLResponse(
+            url: url,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: stub.headers)
+    else { return }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -84,18 +84,7 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
       return
     }
-    guard
-        let response = makeStubResponse(
-            url: request.url,
-            statusCode: stub.statusCode,
-            headerFields: stub.headers)
-    else {
-        client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-        return
-    }
-    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-    client?.urlProtocol(self, didLoad: stub.data)
-    client?.urlProtocolDidFinishLoading(self)
+    deliverStubbedResponse(data: stub.data, statusCode: stub.statusCode, headerFields: stub.headers)
   }
 
   override func stopLoading() {

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -89,7 +89,10 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
             url: request.url,
             statusCode: stub.statusCode,
             headerFields: stub.headers)
-    else { return }
+    else {
+        client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+        return
+    }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -94,5 +94,7 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
     client?.urlProtocolDidFinishLoading(self)
   }
 
-  override func stopLoading() {}
+  override func stopLoading() {
+    // Intentionally empty: stubbed URL protocol has no real load to stop.
+  }
 }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -41,11 +41,10 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
       return
     }
-    guard let url = request.url,
-          let response = HTTPURLResponse(
-            url: url,
+    guard
+        let response = makeStubResponse(
+            url: request.url,
             statusCode: stub.statusCode,
-            httpVersion: "HTTP/1.1",
             headerFields: stub.headers)
     else { return }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -46,7 +46,10 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
             url: request.url,
             statusCode: stub.statusCode,
             headerFields: stub.headers)
-    else { return }
+    else {
+        client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+        return
+    }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -50,5 +50,7 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)
   }
-  override func stopLoading() {}
+  override func stopLoading() {
+    // Intentionally empty: stubbed URL protocol has no real load to stop.
+  }
 }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -41,11 +41,13 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
       return
     }
-    let response = HTTPURLResponse(
-      url: request.url!,
-      statusCode: stub.statusCode,
-      httpVersion: "HTTP/1.1",
-      headerFields: stub.headers)!
+    guard let url = request.url,
+          let response = HTTPURLResponse(
+            url: url,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: stub.headers)
+    else { return }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -41,18 +41,7 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
       return
     }
-    guard
-        let response = makeStubResponse(
-            url: request.url,
-            statusCode: stub.statusCode,
-            headerFields: stub.headers)
-    else {
-        client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-        return
-    }
-    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-    client?.urlProtocol(self, didLoad: stub.data)
-    client?.urlProtocolDidFinishLoading(self)
+    deliverStubbedResponse(data: stub.data, statusCode: stub.statusCode, headerFields: stub.headers)
   }
   override func stopLoading() {
     // Intentionally empty: stubbed URL protocol has no real load to stop.

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/StubResponseFactory.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/StubResponseFactory.swift
@@ -3,21 +3,32 @@
 
 import Foundation
 
-/// Builds an `HTTPURLResponse` for a stubbed URL request.
-///
-/// Shared by the test `URLProtocol` stubs so response construction lives in
-/// exactly one place. Returns `nil` when `url` cannot be resolved or the
-/// response cannot be constructed — callers treat that as a failed stub hit.
-func makeStubResponse(
-    url: URL?,
-    statusCode: Int,
-    headerFields: [String: String]?
-) -> HTTPURLResponse? {
-    guard let url else { return nil }
-    return HTTPURLResponse(
-        url: url,
-        statusCode: statusCode,
-        httpVersion: "HTTP/1.1",
-        headerFields: headerFields
-    )
+extension URLProtocol {
+    /// Delivers `data` as a successful stubbed HTTP response for this
+    /// protocol's own request, then finishes loading.
+    ///
+    /// Reports `URLError(.badServerResponse)` via `didFailWithError` when the
+    /// response cannot be constructed — never returns silently, which would
+    /// leave the session request unresolved until timeout.
+    func deliverStubbedResponse(
+        data: Data,
+        statusCode: Int,
+        headerFields: [String: String]?
+    ) {
+        guard let client else { return }
+        let response = request.url.flatMap {
+            HTTPURLResponse(
+                url: $0,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: headerFields)
+        }
+        guard let response else {
+            client.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client.urlProtocol(self, didLoad: data)
+        client.urlProtocolDidFinishLoading(self)
+    }
 }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/StubResponseFactory.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/StubResponseFactory.swift
@@ -1,0 +1,23 @@
+// StubResponseFactory.swift
+// GitHubClient
+
+import Foundation
+
+/// Builds an `HTTPURLResponse` for a stubbed URL request.
+///
+/// Shared by the test `URLProtocol` stubs so response construction lives in
+/// exactly one place. Returns `nil` when `url` cannot be resolved or the
+/// response cannot be constructed — callers treat that as a failed stub hit.
+func makeStubResponse(
+    url: URL?,
+    statusCode: Int,
+    headerFields: [String: String]?
+) -> HTTPURLResponse? {
+    guard let url else { return nil }
+    return HTTPURLResponse(
+        url: url,
+        statusCode: statusCode,
+        httpVersion: "HTTP/1.1",
+        headerFields: headerFields
+    )
+}

--- a/Sources/RunBot/Views/Settings/Components/UpdateSettingsSection.swift
+++ b/Sources/RunBot/Views/Settings/Components/UpdateSettingsSection.swift
@@ -144,7 +144,10 @@ struct UpdateSettingsSection: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 24)
-                Button("Install & Relaunch") {}
+                Button("Install & Relaunch") {
+                    // Intentionally empty: placeholder — button is disabled until
+                    // install-and-relaunch wiring lands.
+                }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
                     .disabled(true)

--- a/Sources/RunBot/migration/RunBotDesktopApp.swift
+++ b/Sources/RunBot/migration/RunBotDesktopApp.swift
@@ -33,7 +33,10 @@ struct RunBotDesktopApp: App {
                 // OAuthCredentialController lives in GitHubClient; sign-in UI is
                 // presented by AuthenticationSection inside the settings detail view.
             },
-            onSignOut: {}
+            onSignOut: {
+                // Intentionally empty: sign-out UI is handled by
+                // AuthenticationSection; no app-level teardown is required.
+            }
         ))
         _logFetcher = State(initialValue: LogFetcher())
     }

--- a/Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift
+++ b/Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift
@@ -27,7 +27,9 @@ import GitHubClient
 public struct GitHubLoggerAdapter: GitHubLogger {
 
     /// Creates a new `GitHubLoggerAdapter` instance.
-    public init() {}
+    public init() {
+        // Intentionally empty: stateless forwarding adapter needs no initialisation.
+    }
 
     /// Forwards a message from `GitHubClient` into `os.Logger` via the RunBot
     /// `log()` free function.

--- a/Sources/RunBotCore/Platform/ProcessRunner.swift
+++ b/Sources/RunBotCore/Platform/ProcessRunner.swift
@@ -330,7 +330,9 @@ public enum ProcessRunner {
         // Empty sync barrier — blocks until drainQueue's readDataToEndOfFile() finishes.
         // This is the sole happens-before edge; no work belongs inside the closure.
         // See doc comment above for why this DispatchQueue.sync is intentionally retained.
-        drainQueue.sync {}
+        drainQueue.sync {
+            // Intentionally empty: barrier-only sync — the happens-before edge is the work.
+        }
         let outputData = outputBox.withLock { $0 }
         log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableName)", category: .services)
         continuation.resume(returning: Result(

--- a/Sources/RunBotCore/Runner/Models/RunnerState.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerState.swift
@@ -62,7 +62,9 @@ public final class RunnerState {
     // MARK: - Init
 
     /// Creates a default-initialised `RunnerState` with all properties at their zero values.
-    public init() {}
+    public init() {
+        // Intentionally empty: property defaults define the zero state.
+    }
 
     // MARK: - Auto-update storage (written via UpdateStateProviding.apply(_:))
 

--- a/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
@@ -77,7 +77,9 @@ final class PollLoopCoordinator: @unchecked Sendable {
     // MARK: - Init
 
     /// Creates a new coordinator with all task handles set to `nil`.
-    init() {}
+    init() {
+        // Intentionally empty: optional handles start as `nil` by declaration.
+    }
 
     // ⚠️ Load-bearing deinit: RunnerPoller's poll task captures `self` (RunnerPoller)
     // strongly via `while let self`. The cycle (RunnerPoller → pollLoop → Task → RunnerPoller)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollLoop.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollLoop.swift
@@ -90,24 +90,33 @@ extension RunnerPoller {
       Task { [weak self] in
         await self?.fetch()
         while let self, !Task.isCancelled {
-          let interval = await self.nextPollInterval()
-          log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
-          do {
-            try await Task.sleep(for: .seconds(interval))
-          } catch is CancellationError {
-            log("RunnerPoller › poll loop — CancellationError, exiting cleanly", category: .runner)
-            break
-          } catch {
-            log("RunnerPoller › poll loop — unexpected error \(error), exiting", category: .runner)
-            break
-          }
-          guard !Task.isCancelled else {
-            log("RunnerPoller › poll loop — cancelled after sleep, exiting", category: .runner)
-            break
-          }
-          await self.fetch()
+          guard await self.waitForNextTickAndFetch() else { break }
         }
       })
+  }
+
+  /// Sleeps for the adaptive interval, then performs one fetch.
+  ///
+  /// - Returns: `false` when the poll loop must exit (cancelled or unexpected
+  ///   sleep error); `true` to continue looping.
+  private func waitForNextTickAndFetch() async -> Bool {
+    let interval = await nextPollInterval()
+    log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
+    do {
+      try await Task.sleep(for: .seconds(interval))
+    } catch is CancellationError {
+      log("RunnerPoller › poll loop — CancellationError, exiting cleanly", category: .runner)
+      return false
+    } catch {
+      log("RunnerPoller › poll loop — unexpected error \(error), exiting", category: .runner)
+      return false
+    }
+    guard !Task.isCancelled else {
+      log("RunnerPoller › poll loop — cancelled after sleep, exiting", category: .runner)
+      return false
+    }
+    await fetch()
+    return true
   }
 
   // MARK: - Adaptive-interval counters
@@ -133,9 +142,11 @@ extension RunnerPoller {
   /// Returns `true` when at least one job or action group is currently active
   /// (in-progress or queued).
   func hasActiveWork() -> Bool {
-    let hasActiveJobs = jobs.contains { $0.jobStatus == .inProgress || $0.jobStatus == .queued }
-    let hasActiveActions = actions.contains {
-      $0.groupStatus == .inProgress || $0.groupStatus == .queued
+    let hasActiveJobs = jobs.contains { job in
+      job.jobStatus == .inProgress || job.jobStatus == .queued
+    }
+    let hasActiveActions = actions.contains { action in
+      action.groupStatus == .inProgress || action.groupStatus == .queued
     }
     return hasActiveJobs || hasActiveActions
   }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollLoop.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollLoop.swift
@@ -44,7 +44,10 @@ extension RunnerPoller {
       // exits. Without this, ARC may drop `observer` immediately after the `let`
       // binding above goes out of scope (the Task captures `self` weakly and the relay
       // is not otherwise retained), silently stopping scope-change detection.
-      withExtendedLifetime(observer) {}
+      withExtendedLifetime(observer) {
+          // Intentionally empty: body is a no-op — the call itself extends the
+          // relay's lifetime past the for-await loop (see comment above).
+      }
     }
     pollLoop.setScopeObservationTask(newTask)
   }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -66,5 +66,7 @@ public actor MockPoller: RunnerPollerProtocol {
     }
 
     /// No-op. Does not start a poll loop or make any network calls.
-    public func start() async {}
+    public func start() async {
+        // Intentionally empty: inert protocol default for preview/test contexts.
+    }
 }

--- a/Sources/RunBotCore/Runner/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunBotCore/Runner/Services/DefaultRunnerLabelsService.swift
@@ -21,7 +21,9 @@ import GitHubClient
 /// no signing, no entitlements.
 public struct DefaultRunnerLabelsService: RunnerLabelsService, Sendable {
     /// Creates a new `DefaultRunnerLabelsService`.
-    public init() {}
+    public init() {
+        // Intentionally empty: stateless service holds no stored properties.
+    }
 
     /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`
     /// by delegating to the `patchRunnerLabels` free function.

--- a/Sources/RunBotCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerLifecycleService.swift
@@ -13,7 +13,9 @@ import GitHubClient
 public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
 
     /// Creates a new `RunnerLifecycleService` instance.
-    public init() {}
+    public init() {
+        // Intentionally empty: stateless service holds no stored properties.
+    }
 
     // MARK: - Start
 

--- a/Sources/RunBotCore/Utilities/ISO8601DateParser.swift
+++ b/Sources/RunBotCore/Utilities/ISO8601DateParser.swift
@@ -31,7 +31,9 @@ public actor ISO8601DateParser {
     public static let shared = ISO8601DateParser()
 
     /// Private initialiser — callers must use `shared`.
-    private init() {}
+    private init() {
+        // Intentionally empty: singleton; formatters are created lazily per call.
+    }
 
     /// Parses standard and fractional ISO-8601 timestamps.
     ///

--- a/Sources/RunBotCore/Utilities/ISO8601DateParser.swift
+++ b/Sources/RunBotCore/Utilities/ISO8601DateParser.swift
@@ -32,7 +32,7 @@ public actor ISO8601DateParser {
 
     /// Private initialiser — callers must use `shared`.
     private init() {
-        // Intentionally empty: singleton; formatters are created lazily per call.
+        // Intentionally empty: formatter properties initialize from declaration defaults.
     }
 
     /// Parses standard and fractional ISO-8601 timestamps.

--- a/Tests/RunBotCoreTests/Helpers/TestModelHelpers.swift
+++ b/Tests/RunBotCoreTests/Helpers/TestModelHelpers.swift
@@ -27,9 +27,9 @@ import GitHubClient
 /// is a programming error that must surface immediately.
 func decodeFixture<T: Decodable>(_ type: T.Type, from json: String) -> T {
     guard let data = json.data(using: .utf8),
-          let decoded = try? JSONDecoder().decode(T.self, from: data)
+          let decoded = try? JSONDecoder().decode(type, from: data)
     else {
-        fatalError("\(T.self) fixture JSON failed to decode: \(json)")
+        fatalError("\(type) fixture JSON failed to decode: \(json)")
     }
     return decoded
 }

--- a/Tests/RunBotCoreTests/Helpers/TestModelHelpers.swift
+++ b/Tests/RunBotCoreTests/Helpers/TestModelHelpers.swift
@@ -120,7 +120,10 @@ extension GitHubStep {
         let json = """
         {"number":\(n),"name":\"\(name)\","status":\"\(status)\","conclusion":\(conclusionJSON),"started_at":\(startJSON),"completed_at":\(endJSON)}
         """
-        self = try! JSONDecoder().decode(GitHubStep.self, from: Data(json.utf8)) // swiftlint:disable:this force_try
+        guard let decoded = try? JSONDecoder().decode(GitHubStep.self, from: Data(json.utf8)) else {
+            fatalError("GitHubStep fixture JSON failed to decode: \(json)")
+        }
+        self = decoded
     }
 
     /// Test-only init: typed `JobStatus` / `JobConclusion` overload.
@@ -160,7 +163,10 @@ extension GitHubRunner {
         let json = """
         {"id":\(id),"name":\"\(name)\","status":\"\(status.rawValue)\","busy":\(busy ? "true" : "false"),"labels":[]}
         """
-        self = try! JSONDecoder().decode(GitHubRunner.self, from: Data(json.utf8)) // swiftlint:disable:this force_try
+        guard let decoded = try? JSONDecoder().decode(GitHubRunner.self, from: Data(json.utf8)) else {
+            fatalError("GitHubRunner fixture JSON failed to decode: \(json)")
+        }
+        self = decoded
     }
 
     /// Convenience forwarder for tests that call `runner.displayStatus` without args.

--- a/Tests/RunBotCoreTests/Helpers/TestModelHelpers.swift
+++ b/Tests/RunBotCoreTests/Helpers/TestModelHelpers.swift
@@ -17,6 +17,23 @@ import Foundation
 import GitHubClient
 @testable import RunBotCore
 
+// MARK: - Fixture JSON decoding
+
+/// Decodes a fixture `Decodable` type from a JSON string.
+///
+/// Shared by the JSON round-trip fixture constructors so the decode-and-trap
+/// logic lives in exactly one place. Traps with the offending JSON when
+/// decoding fails — fixture strings are compile-time constants, so a failure
+/// is a programming error that must surface immediately.
+func decodeFixture<T: Decodable>(_ type: T.Type, from json: String) -> T {
+    guard let data = json.data(using: .utf8),
+          let decoded = try? JSONDecoder().decode(T.self, from: data)
+    else {
+        fatalError("\(T.self) fixture JSON failed to decode: \(json)")
+    }
+    return decoded
+}
+
 // MARK: - ActiveJob test convenience inits
 
 extension ActiveJob {
@@ -120,10 +137,7 @@ extension GitHubStep {
         let json = """
         {"number":\(n),"name":\"\(name)\","status":\"\(status)\","conclusion":\(conclusionJSON),"started_at":\(startJSON),"completed_at":\(endJSON)}
         """
-        guard let decoded = try? JSONDecoder().decode(GitHubStep.self, from: Data(json.utf8)) else {
-            fatalError("GitHubStep fixture JSON failed to decode: \(json)")
-        }
-        self = decoded
+        self = decodeFixture(GitHubStep.self, from: json)
     }
 
     /// Test-only init: typed `JobStatus` / `JobConclusion` overload.
@@ -163,10 +177,7 @@ extension GitHubRunner {
         let json = """
         {"id":\(id),"name":\"\(name)\","status":\"\(status.rawValue)\","busy":\(busy ? "true" : "false"),"labels":[]}
         """
-        guard let decoded = try? JSONDecoder().decode(GitHubRunner.self, from: Data(json.utf8)) else {
-            fatalError("GitHubRunner fixture JSON failed to decode: \(json)")
-        }
-        self = decoded
+        self = decodeFixture(GitHubRunner.self, from: json)
     }
 
     /// Convenience forwarder for tests that call `runner.displayStatus` without args.

--- a/Tests/RunBotCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestDoubles.swift
@@ -131,17 +131,29 @@ actor SpyProxyStore: RunnerProxyStoreProtocol {
 /// store and a write log.
 actor MockScopePreferencesStore: ScopePreferencesStoreProtocol {
     func preferences(for _: String) -> ScopePreferences { ScopePreferences() }
-    func setPreferences(_: ScopePreferences, for _: String) {}
+    func setPreferences(_: ScopePreferences, for _: String) {
+        // Intentionally empty: stateless mock — writes are discarded by design.
+    }
     func alias(for _: String) -> String? { nil }
-    func setAlias(_: String?, for _: String) {}
+    func setAlias(_: String?, for _: String) {
+        // Intentionally empty: stateless mock — writes are discarded by design.
+    }
     func displayName(for scope: String) -> String { scope }
     func pollingInterval(for _: String) -> Int? { nil }
-    func setPollingInterval(_: Int?, for _: String) {}
+    func setPollingInterval(_: Int?, for _: String) {
+        // Intentionally empty: stateless mock — writes are discarded by design.
+    }
     func notifyOnSuccess(for _: String) -> Bool? { nil }
-    func setNotifyOnSuccess(_: Bool?, for _: String) {}
+    func setNotifyOnSuccess(_: Bool?, for _: String) {
+        // Intentionally empty: stateless mock — writes are discarded by design.
+    }
     func notifyOnFailure(for _: String) -> Bool? { nil }
-    func setNotifyOnFailure(_: Bool?, for _: String) {}
-    func cleanUp(scope _: String) {}
+    func setNotifyOnFailure(_: Bool?, for _: String) {
+        // Intentionally empty: stateless mock — writes are discarded by design.
+    }
+    func cleanUp(scope _: String) {
+        // Intentionally empty: nothing to clean up in a stateless mock.
+    }
     // Intentionally does not write back — this mock is stateless by design.
     // `setPreferences` is also a no-op here. If you need state persistence,
     // use `FakeScopePreferencesStore` instead.

--- a/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
@@ -99,7 +99,10 @@ func makeGitHubRunner(
     let json = """
     {"id":\(id),"name":"\(name)","status":"\(status.rawValue)","busy":\(busy ? "true" : "false"),"labels":[]}
     """
-    return try! JSONDecoder().decode(GitHubRunner.self, from: Data(json.utf8)) // swiftlint:disable:this force_try
+    guard let decoded = try? JSONDecoder().decode(GitHubRunner.self, from: Data(json.utf8)) else {
+        fatalError("GitHubRunner fixture JSON failed to decode: \(json)")
+    }
+    return decoded
 }
 
 // MARK: - WorkflowActionGroup

--- a/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
@@ -98,10 +98,7 @@ func makeGitHubRunner(status: RunnerStatus, id: Int = 1, name: String = "r", bus
     let json = """
     {"id":\(id),"name":"\(name)","status":"\(status.rawValue)","busy":\(busy ? "true" : "false"),"labels":[]}
     """
-    guard let decoded = try? JSONDecoder().decode(GitHubRunner.self, from: Data(json.utf8)) else {
-        fatalError("GitHubRunner fixture JSON failed to decode: \(json)")
-    }
-    return decoded
+    return decodeFixture(GitHubRunner.self, from: json)
 }
 
 // MARK: - WorkflowActionGroup

--- a/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
@@ -39,11 +39,15 @@ internal let fixtureZipBase64 =
     "ZWNrb3V0LnR4dFBLAQIUAxQAAAAIACp7/1x94DpHeAAAAKQAAAAaAAAAAAAAAAAAAACAAWYAAABy" +
     "ZWxlYXNlLzdfQ29tcGxldGUgam9iLnR4dFBLBQYAAAAAAgACAIwAAAAWAQAAAAA="
 
-/// Decoded bytes of the fixture ZIP. Force-unwrap is intentional: a decode failure
-/// means the committed constant is corrupt, which must be caught immediately.
+/// Decoded bytes of the fixture ZIP. A decode failure means the committed
+/// constant is corrupt, which must be caught immediately.
 /// Declared as `let` so the base64 decode runs once per process, not once per test access.
-internal let fixtureZip: Data =
-    Data(base64Encoded: fixtureZipBase64, options: .ignoreUnknownCharacters)!
+internal let fixtureZip: Data = {
+    guard let decoded = Data(base64Encoded: fixtureZipBase64, options: .ignoreUnknownCharacters) else {
+        fatalError("Fixture ZIP base64 constant failed to decode")
+    }
+    return decoded
+}()
 
 // MARK: - Subprocess availability probe
 
@@ -88,12 +92,7 @@ func makeRunnerModel(
 // use `GitHubRunner` + the `displayStatus(metrics:)` extension from RunBotCore.
 // This factory function bridges the gap.
 
-func makeGitHubRunner(
-    id: Int = 1,
-    name: String = "r",
-    busy: Bool = false,
-    status: RunnerStatus
-) -> GitHubRunner {
+func makeGitHubRunner(status: RunnerStatus, id: Int = 1, name: String = "r", busy: Bool = false) -> GitHubRunner {
     // GitHubRunner.labels is [GitHubRunnerLabel] (not [String]) and has no public
     // memberwise init, so we round-trip through JSON to construct a test instance.
     let json = """


### PR DESCRIPTION
Closes #2956 (resolves #2955 Sonar findings). Stacked on #2967 — base is `fix-migrate-to-app-shell-step-24`.

## Batch 1 — GitHubClient & OAuthTokenKit ✅
- **S1186 (9 sites):** `// Intentionally empty: …` comments added (no-op inits, null-object `invalidate()`, silent logger, stub `stopLoading()` overrides, token-store mock).
- **S2699:** the reported `try!` occurrences in `OAuthServiceTests` no longer exist — verified, no change.

## Batch 2 — RunBotCore ✅
- **S1186 (9/10 sites):** annotated stateless service inits, zero-state model init, `PollLoopCoordinator` init, protocol default `start()`, `withExtendedLifetime` keep-alive, `drainQueue.sync` barrier, singleton init.
- Tenth site (`PanelSheetState.swift`) was deleted with the panel-era state types on step-24.

## Batch 3 — App layer ✅
- **2 of 6 sites remain** and were annotated (`onSignOut`, disabled Install & Relaunch placeholder). MenuBarKit files deleted with the package; InlineJobRowsView / PanelMainView / SettingsView+Sections removed in the windowed-app migration.

## Batch 4 — Tests ✅
- **S2699:** 3× `try!` fixture construction → `try?` + `fatalError` with offending JSON; `force_try` suppressions removed.
- **S1186:** 6 stateless mock write methods on `MockScopePreferencesStore` annotated.
- Other reported sites no longer exist at those locations.

## Follow-on quality-gate fixes (same PR)
Fixing the above surfaced findings from other analyzers, resolved here:
- **DeepSource:** force-unwraps → guard-let in test stubs (`makeStubResponse` helper); `fixtureZip` decode via guard-let; `makeGitHubRunner` param order; named multiline closure args + extracted `waitForNextTickAndFetch()` from `RunnerPoller.start()`.
- **Sonar S1172:** discarded param names on `SilentGitHubLogger.log`.

No runtime behaviour changed. All gates green: Swift Test, SwiftLint (--strict), Periphery, SonarCloud quality gate (OK), DeepSource.
