### PR TITLE
docs(app): restore load-bearing sizing contracts as comments (#2986)

### DIFF
--- a/Sources/RunBot/AppShell/AppShellView.swift
+++ b/Sources/RunBot/AppShell/AppShellView.swift
@@ -9,6 +9,30 @@ import SwiftUI
 /// Owns the top-level sidebar selection and the shared workflow selection so
 /// the content column (workflow hierarchy) and detail column (step log) stay
 /// in sync (issue #2880).
+///
+/// ## SIZING CONTRACT — restored lessons from the popover era
+/// (refs #375–377 side-jump regressions, #2278/#2279 stale-cap regressions,
+/// #2305 width inheritance)
+///
+/// The windowed shell replaced the anchored menu-bar panel, but the failure
+/// modes that shaped that design still apply to window/column sizing:
+///
+/// - ONE MEASUREMENT, ONE OWNER. Exactly one layer may measure content and
+///   derive a size from it. The old panel regressed repeatedly when two
+///   independent height caps and three measurement sources (a content
+///   GeometryReader, `.preferredContentSize`, and a manual `setFrame`) could
+///   disagree. Here the `Window` scene owns the min/default size and each
+///   column owns only its width range — no view below the shell re-measures.
+/// - NEVER size a window from `.preferredContentSize`, an invisible helper
+///   pass, or a GeometryReader feedback loop. That was the direct cause of
+///   the side-jump family of bugs (#375–377); the fix each time was to
+///   collapse to a single owner.
+/// - WRAPPERS MUST NOT IMPOSE WIDTH ON ROUTED CHILDREN (#2305). The old
+///   popover wrapper applied its own `minWidth/maxWidth`, which stretched the
+///   fixed-width Settings screen to the list's width. Width ranges live where
+///   the column lives: `navigationSplitViewColumnWidth` here, and per-view
+///   caps (e.g. the 820 pt readability cap in `SettingsDetailView`) in the
+///   views that own them.
 struct AppShellView: View {
     /// Currently selected sidebar section. Defaults to Workflows.
     @State private var selection: AppSection? = .workflows
@@ -71,6 +95,10 @@ struct AppShellView: View {
             )
         }
         .navigationSplitViewStyle(.balanced)
+        // Content min-size floor. Must stay in sync with
+        // `.windowResizability(.contentMinSize)` + `.defaultSize` in
+        // RunBotDesktopApp — two sources that must never disagree (see the
+        // one-measurement rule above).
         .frame(minWidth: 720, minHeight: 480)
     }
 }

--- a/Sources/RunBot/Features/LocalRunners/RunnerDetailView.swift
+++ b/Sources/RunBot/Features/LocalRunners/RunnerDetailView.swift
@@ -56,6 +56,9 @@ struct RunnerDetailView: View {
             .padding(.horizontal, 32)
             .padding(.top, 12)
             .padding(.bottom, 28)
+            // Same load-bearing 820 pt readability cap as SettingsDetailView —
+            // keep the two in sync. Do not replace with idealWidth: it is a
+            // preference, not a constraint (see AppShellView sizing contract).
             .frame(maxWidth: 820, alignment: .topLeading)
         }
         .task(id: runner.id) { await loadDisplayFields(for: runner) }

--- a/Sources/RunBot/Features/Settings/SettingsDetailView.swift
+++ b/Sources/RunBot/Features/Settings/SettingsDetailView.swift
@@ -32,6 +32,24 @@ import SwiftUI
 ///   or `.unauthenticated` to match main's toggle logic.
 /// - A `.task` on `AuthenticationSection` runs `refreshAuthentication()` once
 ///   on mount so `environmentState` exits `.checking`.
+///
+/// ## SIZING CONTRACT — condensed from the pre-AppShell SettingsView guards
+/// The popover-era `SettingsView` carried a WIDTH/HEIGHT CONTRACT block built
+/// from several layout regressions. The constraints that still apply here:
+///
+/// - The `maxWidth: 820` cap in `body` is LOAD-BEARING for readability.
+///   ❌ Do not remove it — detail content then stretches to the full window
+///   width. ❌ Do not replace it with `.frame(idealWidth:)` — idealWidth is a
+///   preference, not a constraint, and is ignored when the parent offers more.
+/// - ❌ Do not wrap this view's root `ScrollView` in a GeometryReader to
+///   measure it — measurement has exactly one owner (see the SIZING CONTRACT
+///   on `AppShellView`). Measuring here reintroduces the multi-source
+///   disagreement that caused #2278/#2279 and the side-jump family (#375–377).
+/// - `.fixedSize(horizontal: false, vertical: true)` on multi-line rows in
+///   the section views (Updates, General, Authentication cards) is
+///   LOAD-BEARING inside a ScrollView: without it, text views under-report
+///   their height (the old "height-inheritance" regression class — content
+///   clipped instead of growing).
 @MainActor
 struct SettingsDetailView: View {
 


### PR DESCRIPTION
Closes #2986 (partial — comment restorations only; see "Out of scope" below)
Stacked on: fix-migrate-to-app-shell-step-27

## What

Comment-only change. Restores the load-bearing sizing/window knowledge that was lost in the AppShell migration, as documented by the audit in #2986. **No code is added or altered** — only `///` doc-comment blocks and `//` line comments were appended to existing declarations.

| File | Restored knowledge | Lost from |
|---|---|---|
| `AppShellView.swift` | SIZING CONTRACT: one-measurement-one-owner rule, `.preferredContentSize` side-jump ban (#375–377), #2278/#2279 stale-cap history, #2305 width-ownership rule, min-size sync note vs `RunBotDesktopApp` | deleted `PanelMainView`, `PanelVisibilityState`, `AppDelegate+PanelSetup` |
| `SettingsDetailView.swift` | Condensed WIDTH/HEIGHT CONTRACT from the old 480 pt `SettingsView`: load-bearing `maxWidth: 820` cap, `idealWidth` ban, GeometryReader single-owner rule, `.fixedSize(horizontal:false, vertical:true)` height-inheritance guard | deleted `SettingsView.swift` |
| `RunnerDetailView.swift` | Pointer comment tying its 820 pt cap to `SettingsDetailView` + the shell sizing contract | same |

## What was deliberately NOT done (per issue triage)

- Items 1–3 of the issue (SIGTERM test, GitHubClient test targets, `SaveRunnerEditsUseCaseTests`) require restoring *code/tests*, which is out of scope for this task — they remain open follow-ups.
- AGENTS.md / docs-ui drift (issue item 4) is a documentation task outside "code comments".
- Comments tied to intentionally deleted subsystems (MenuBarKit internals, popover dim-overlay guards, NavState route history) were not restored — their host code no longer exists.

## Verification

- `swift build` — passes
- `swift test` — 118 tests pass
- `swiftlint lint --strict` — 0 violations
- `periphery scan` — clean

## Summary by Sourcery

Restore load-bearing sizing guidance as comments across the AppShell and related detail views.

Enhancements:
- Restore documentation of the AppShell, settings, and runner view sizing contracts, including single-owner measurement, window sizing coordination, readability caps, and text-height safeguards.

Documentation:
- Document the historical sizing regressions and constraints that must be preserved during future AppShell and detail-view layout changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores load-bearing sizing contracts as comments in `AppShellView`, `SettingsDetailView`, and `RunnerDetailView` to prevent recurring sizing regressions during the AppShell migration. No runtime behavior changes.

- AppShellView: documents one-measurement-one-owner; bans sizing from `.preferredContentSize` or GeometryReader feedback loops; clarifies column width ownership; notes the content min-size must stay in sync with `RunBotDesktopApp` defaults.
- SettingsDetailView: reintroduces the 820 pt max-width readability cap; bans `.idealWidth`; reiterates single-owner measurement; explains why `.fixedSize(horizontal: false, vertical: true)` is required for multi-line rows.
- RunnerDetailView: ties its 820 pt cap to the shared sizing contract used by Settings.

<sup>Written for commit 3d19471ddc9bc9735a280f225854d3fe60b2e3ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

----
## Summary by Gitar

- **Documentation updates:**
    - Fixed 7 inaccuracies in `docs/deployment.md` covering target descriptions, test commands, file headers, and app updater types

<sub>This will update automatically on new commits.</sub>