### PR TITLE
docs(deployment): fix 7 inaccuracies in deployment.md

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -270,12 +270,12 @@ needs it — mark intentional keeps with `// periphery:ignore`.
 
 ### Tests
 ```bash
-swift test --filter RunBotCoreTests
+swift test
 ```
-> ⚠️ This is exactly what CI runs (`.github/workflows/swift-test.yml`, on `macos-26`). Bare
-> `swift test` is not the CI command. The UI tests (`RunBotUITests`) run separately via
-> `xcodebuild` on the self-hosted runner (`.github/workflows/ui-tests.yml`) and are **not** part
-> of the SwiftPM test run — don't try to run them with `swift test`.
+> ⚠️ This is exactly what CI runs (`.github/workflows/swift-test.yml`, on `macos-26`). CI also
+> runs `swift test` inside `Packages/GitHubClient` as a second step. The UI tests (`RunBotUITests`)
+> run separately via `xcodebuild` on the self-hosted runner (`.github/workflows/ui-tests.yml`) and are
+> **not** part of the SwiftPM test run — don't try to run them with `swift test`.
 
 Add new tests under `Tests/RunBotCoreTests/` alongside any new logic in `RunBotCore`; reuse
 the shared doubles/fixtures in `Tests/RunBotCoreTests/TestSupport/`.
@@ -538,10 +538,14 @@ At launch, `AppUpdater.checkAndHandle(state:)` hits `GET /repos/.../releases`,
 sorts by semver (not publish date), and filters by the `betaChannel` preference
 from `AppPreferencesStore`. The result is applied to `RunnerState` via
 `UpdateStateProviding.apply(_ phase:)`, which advances the state machine
-(`idle` → `available` → `downloading` → `ready` / `failed`). After the
-launch-time check, `AppUpdater.scheduleBackgroundCheck(state:)` registers a
+(`idle` → `available(version)` → `downloading(version)` → `ready(version)` / `failed(version)`).
+After the launch-time check, `AppUpdater.scheduleBackgroundCheck(state:)` registers a
 repeating background check at `AppUpdater.checkInterval`. Settings → About
 reads `RunnerState.availableUpdate` and shows the update row if non-nil.
+
+> **Note:** `checkAndHandle(state:)` and `scheduleBackgroundCheck(state:)` are entry points in
+> the `runbot-hq/AppUpdater` library, not defined in this repo.
+
 For full details see [Update Flow](#update-flow) below.
 
 ### Dry run

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,7 +69,8 @@ No `gh` CLI or `gh auth login` is required — see [Auth](#auth-during-developme
 ```
 RunBotCore      (library)     — pure logic, no UI; the testable core
 RunBot          (executable)  — AppKit/SwiftUI app; depends on RunBotCore
-RunBotCoreTests (test)         — swift-testing suite for the core
+RunBotCoreTests (test)        — swift-testing suite for the core
+RunBotTests     (test)        — swift-testing suite for the app target
 ```
 
 `RunBotCore` must never import the `RunBot` app target — app-layer dependencies are injected
@@ -97,7 +98,7 @@ No IDE required.
 ```bash
 swift run
 ```
-Compiles incrementally and launches the app. The menu bar icon appears immediately. `Ctrl+C` to stop.
+Compiles incrementally and launches the app. The AppShell window opens and the menu bar icon appears. `Ctrl+C` to stop.
 
 ### Type-check after changes
 ```bash
@@ -113,8 +114,7 @@ swift package clean && swift build
 ```bash
 swift package show-dependencies
 ```
-Third-party dependencies in the root package are revision-pinned in this
-repository's `Package.swift`.
+The root `Package.swift` has no direct third-party dependencies.
 
 Organization-owned packages (`runbot-hq/*`) track `branch: "main"` and are
 never revision-pinned. `MarkdownKit` is resolved from
@@ -156,7 +156,7 @@ cd ~/run-bot && \
 pkill -x RunBot 2>/dev/null || true && \
 sleep 1 && \
 rm -rf dist/ && \
-touch Sources/RunBot/App/AppDelegate.swift && \
+touch Sources/RunBot/App/RunBotDesktopApp.swift && \
 bash build.sh && \
 sleep 1 && \
 log stream --level debug \
@@ -256,9 +256,9 @@ swiftlint lint --strict
 > ⚠️ **Use `--strict`.** A bare `swiftlint` passes locally while CI fails, because `--strict`
 > promotes every warning to an error — which is how CI runs it
 > (`.github/workflows/swiftlint.yml`). Common gotchas enforced by `.swiftlint.yml`:
-> - **`file_header`** — every file must start with `// <Filename>.swift` then `// RunBot`.
+> - **`file_header`** — every file must start with `// <Filename>.swift` then `// RunBot`, `// AppUpdater`, or `// GitHubClient` (whichever module the file belongs to).
 > - **`missing_docs`** — every declaration needs a `///` doc comment.
-> - **`sorted_imports`**, and **`large_tuple`** (no 3+ member tuples — use a small struct).
+> - **`sorted_imports`** — keep `import` statements alphabetically ordered.
 
 ### Dead-code scan
 ```bash
@@ -654,11 +654,11 @@ Code-signing identity verification (`codesign --verify`) is deferred to [#1795](
 
 | Type | Role |
 |---|---|
-| `UpdateChecker` | Fetches releases, semver comparison, selects best asset |
-| `AutoUpdater` | Caseless enum; static functions for download, install, relaunch |
+| `UpdateChecker` | Fetches releases, semver comparison, selects best asset — lives in `runbot-hq/AppUpdater` |
+| `AutoUpdater` | Caseless enum; static functions for download, install, relaunch — lives in `runbot-hq/AppUpdater` |
 | `RunnerState` | `@Observable @MainActor`; holds `availableUpdate`, `isInstalling`, `updateActionFailed` |
-| `AutoUpdaterDefaults` | `UserDefaults` keys for persisting version + cache path |
-| `AvailableRelease` | Decoded model; includes `checksumURL` for SHA-256 verification |
+| `AutoUpdaterDefaults` | `UserDefaults` keys for persisting version + cache path — lives in `runbot-hq/AppUpdater` |
+| `AvailableRelease` | Decoded model; includes `checksumURL` for SHA-256 verification — lives in `runbot-hq/AppUpdater` |
 
 #### Design constraints
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,14 +64,18 @@ No `gh` CLI or `gh auth login` is required — see [Auth](#auth-during-developme
 
 ## Development environment
 
-### Targets
+### SwiftPM targets
 
 ```
-RunBotCore      (library)     — pure logic, no UI; the testable core
+RunBotCore      (library)     — non-UI domain and platform services; models, polling,
+                                persistence, process execution, and log handling
 RunBot          (executable)  — AppKit/SwiftUI app; depends on RunBotCore
 RunBotCoreTests (test)        — swift-testing suite for the core
 RunBotTests     (test)        — swift-testing suite for the app target
 ```
+
+`RunBotUITests` is an Xcode/XcodeGen-driven UI test target — it is not part of the SwiftPM
+build graph and cannot be run with `swift test`. See [Triggering UI Tests](#triggering-ui-tests).
 
 `RunBotCore` must never import the `RunBot` app target — app-layer dependencies are injected
 via protocols and closures. See [`docs/architecture/file-hierarchy.md`](../architecture/file-hierarchy.md)
@@ -98,7 +102,7 @@ No IDE required.
 ```bash
 swift run
 ```
-Compiles incrementally and launches the app. The AppShell window opens and the menu bar icon appears. `Ctrl+C` to stop.
+Compiles incrementally and opens the RunBot AppShell window. Press `Ctrl+C` in the launching terminal to stop the process.
 
 ### Type-check after changes
 ```bash
@@ -256,7 +260,7 @@ swiftlint lint --strict
 > ⚠️ **Use `--strict`.** A bare `swiftlint` passes locally while CI fails, because `--strict`
 > promotes every warning to an error — which is how CI runs it
 > (`.github/workflows/swiftlint.yml`). Common gotchas enforced by `.swiftlint.yml`:
-> - **`file_header`** — every file must start with `// <Filename>.swift` then `// RunBot`, `// AppUpdater`, or `// GitHubClient` (whichever module the file belongs to).
+> - **`file_header`** — every file must start with `// <Filename>.swift` then the module name, matched by the `required_pattern` in the applicable `.swiftlint.yml`. The root and `Packages/GitHubClient` run separate lint configurations — check the relevant `.swiftlint.yml` rather than relying on a manually-maintained list.
 > - **`missing_docs`** — every declaration needs a `///` doc comment.
 > - **`sorted_imports`** — keep `import` statements alphabetically ordered.
 
@@ -368,12 +372,12 @@ zipping, and creating the GitHub Release — is handled by CI automatically.
    4. **Build** — `bash build.sh` compiles arm64, assembles `.app`,
       signs ad-hoc, zips to `dist/RunBot.zip` (see [Build internals](#build-internals) below)
    5. **Verify** — confirms the binary is actually present inside the zip
-   6. **Generate SHA-256 sidecar** — computes a `shasum -a 256` digest and writes
-      `RunBot.zip.sha256` alongside the zip. **This step is load-bearing:** `AppUpdater`
-      treats a missing sidecar as a hard failure — every user's in-app update
-      will fall back to the curl install command if the sidecar is absent
+   6. **Sign release zip (Ed25519)** — signs `RunBot.zip` with the `ED25519_PRIVATE_KEY`
+      secret and writes `RunBot.zip.sig` (raw 64-byte signature). **This step is
+      load-bearing:** `AppUpdater` treats a missing or invalid signature as a hard
+      failure — installation will not proceed without a valid `.sig` sidecar
    7. **Tag + push** — creates an annotated git tag and pushes it
-   8. **Create GitHub Release** — attaches both the zip and the SHA-256 sidecar,
+   8. **Create GitHub Release** — attaches both the zip and `RunBot.zip.sig`,
       with `--prerelease` for beta or `--latest` for stable
 
    > **Dry-run via `workflow_dispatch`:** See [Dry run](#dry-run) below for
@@ -457,8 +461,8 @@ ad-hoc codesign without --deep
 ditto creates dist/RunBot.zip
 ```
 
-The output is always `dist/RunBot.zip`. CI then generates the `.sha256` sidecar
-from that zip before attaching both to the GitHub Release.
+The output is always `dist/RunBot.zip`. CI then signs it with Ed25519 to produce
+`RunBot.zip.sig` before attaching both to the GitHub Release.
 
 ### Distribution & install
 
@@ -552,7 +556,7 @@ For full details see [Update Flow](#update-flow) below.
 
 The publish pipeline has a built-in dry-run mode that exercises every step
 — tag computation, duplicate-tag guard, `Info.plist` patching, build, zip
-verification, and SHA-256 sidecar generation — without creating a tag,
+verification, and Ed25519 signing — without creating a tag,
 committing anything, or publishing a GitHub Release.
 
 Use this to verify the pipeline is healthy before shipping a real release,
@@ -578,7 +582,7 @@ or after any changes to `publish.yml` or `build.sh`.
 | Patch `Info.plist` | ✅ | ✅ |
 | Build | ✅ | ✅ |
 | Verify zip | ✅ | ✅ |
-| Generate SHA-256 sidecar | ✅ | ✅ |
+| Sign release zip (Ed25519) | ✅ | ✅ |
 | Commit patched `Info.plist` | ❌ skipped | ✅ |
 | Tag + push | ❌ skipped | ✅ |
 | Create GitHub Release | ❌ skipped | ✅ |
@@ -593,7 +597,7 @@ or after any changes to `publish.yml` or `build.sh`.
 - **Build** — exits 0; no Swift compiler errors
 - **Verify zip** — log line reads:
   `Zip verified: RunBot.app/Contents/MacOS/RunBot is present at archive root.`
-- **Generate SHA-256 sidecar** — log line shows a 64-character hex digest
+- **Sign release zip (Ed25519)** — log line shows `Signed: RunBot.zip.sig (64 bytes)`
 - **Commit patched Info.plist**, **Tag and push**, **Create GitHub Release** —
   all show ❌ (skipped), confirming dry-run mode was active
 
@@ -626,7 +630,7 @@ RunBot checks for updates in the background and presents a single update row in 
    ```
    ~/Library/Caches/io.github.runbot-hq/RunBot-<version>.zip
    ```
-   The version string and cache path are persisted in `UserDefaults` (`AutoUpdaterDefaults`) so the state survives force-quits.
+   The version string and cache path are persisted in `UserDefaults` so the state survives force-quits.
 
 4. **UI state** — Settings → About shows a single `updateActionRow`:
 
@@ -636,7 +640,7 @@ RunBot checks for updates in the background and presents a single update row in 
    | Download complete | **Install & Relaunch** |
    | Failure (any step) | **Download** (browser fallback) |
 
-5. **Install & Relaunch** — When the user taps **Install & Relaunch**, `AutoUpdater.installAndRelaunch` performs the following sequence:
+5. **Install & Relaunch** — When the user taps **Install & Relaunch**, `AppUpdater.installAndRelaunch(state:)` performs the following sequence:
    - Extracts the zip into a temporary directory using `ditto`
    - Replaces the running `RunBot.app` bundle using `FileManager.replaceItem(at:withItemAt:backupItemName:options:resultingItemURL:)` — an atomic rename-based swap; the old bundle is preserved as a named backup and removed on success, so a mid-swap crash cannot leave a half-written bundle
    - Relaunches via `open -n`
@@ -646,23 +650,28 @@ RunBot checks for updates in the background and presents a single update row in 
 
    > ⚠️ **Permission note:** `replaceItem` requires write access to the directory containing `RunBot.app`. This works when RunBot is installed in `~/Applications` (the recommended location). If installed in the system `/Applications` directory, the process will not have write permission and Install & Relaunch will silently fall back to the browser Download button.
 
-6. **Failure fallback** — Any failure during download, checksum verification, or install sets `updateActionFailed = true`. The row then shows a **Download** button that opens the GitHub releases page in the browser. The fallback also triggers when the `RunBot.zip` asset is missing from the release (`updateAssetMissing`).
+6. **Failure fallback** — Any failure during download, signature verification, or install sets `updateActionFailed = true`. The row then shows a **Download** button that opens the GitHub releases page in the browser. The fallback also triggers when the `RunBot.zip` asset is missing from the release (`updateAssetMissing`).
 
-#### Integrity verification — v1 status
+#### Update signature verification
 
-**SHA-256 checksum verification is implemented in v1.** `AutoUpdater.downloadUpdate` fetches the `RunBot.zip.sha256` sidecar asset from the GitHub Release, and `verifyChecksum` computes a `CryptoKit` SHA-256 digest of the downloaded zip and compares it against the expected hex string. A mismatch sets `updateActionFailed = true`.
+Release archives are authenticated with an Ed25519 signature. The publish workflow signs
+`RunBot.zip` and produces `RunBot.zip.sig` (a raw 64-byte Ed25519 signature).
+`AppUpdater` downloads this sidecar and verifies it against the Ed25519 public key embedded
+in `AppDependencies` before installation. A signature mismatch sets `updateActionFailed = true`.
 
-Code-signing identity verification (`codesign --verify`) is deferred to [#1795](https://github.com/runbot-hq/run-bot/issues/1795). The `checksumURL` field is already decoded in `AvailableRelease` so that #1795 can add further verification logic without a model change.
+This is separate from macOS code signing:
+
+- The application bundle is currently ad-hoc signed.
+- The release archive is authenticated with Ed25519.
+- Developer ID signing and notarisation are not currently part of the pipeline.
 
 #### Key types
 
 | Type | Role |
 |---|---|
-| `UpdateChecker` | Fetches releases, semver comparison, selects best asset — lives in `runbot-hq/AppUpdater` |
-| `AutoUpdater` | Caseless enum; static functions for download, install, relaunch — lives in `runbot-hq/AppUpdater` |
-| `RunnerState` | `@Observable @MainActor`; holds `availableUpdate`, `isInstalling`, `updateActionFailed` |
-| `AutoUpdaterDefaults` | `UserDefaults` keys for persisting version + cache path — lives in `runbot-hq/AppUpdater` |
-| `AvailableRelease` | Decoded model; includes `checksumURL` for SHA-256 verification — lives in `runbot-hq/AppUpdater` |
+| `AppUpdater` | Owns update checks, scheduling, download, Ed25519 verification, installation, and relaunch — lives in `runbot-hq/AppUpdater`; instantiated in `AppDependencies` |
+| `RunnerState` | `@Observable @MainActor`; implements the update-state contract consumed by `AppUpdater` and the Settings UI |
+| `SettingsDependencies` | Carries the shared `AppUpdater` instance from the composition root into Settings |
 
 #### Design constraints
 


### PR DESCRIPTION
## What
- Add `RunBotTests` to Targets block
- Fix `swift test` command (bare, not `--filter RunBotCoreTests`); note GitHubClient second step
- Remove `large_tuple` from SwiftLint gotchas (not in `.swiftlint.yml`)
- Expand `file_header` description to include `AppUpdater` and `GitHubClient` modules
- Fix `touch` path in log-stream snippet (`RunBotDesktopApp.swift`, not deleted `AppDelegate.swift`)
- Fix third-party deps claim (root `Package.swift` has no direct third-party deps)
- Annotate update key types table with their actual location (`runbot-hq/AppUpdater`)

## Why
All 7 were factually wrong after the AppShell migration and AppUpdater extraction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes outdated deployment docs and documents Ed25519 release signing to match the AppShell migration and `runbot-hq/AppUpdater` extraction. Prevents incorrect run/test/lint/update steps and aligns update verification with the current pipeline.

- Targets: add `RunBotTests`; clarify `RunBotUITests` is Xcode-only and not runnable via `swift test`.
- Run: previously only a menu bar icon appeared; now the AppShell window opens and the menu bar icon appears.
- Tests: use `swift test`; CI also runs `swift test` in `Packages/GitHubClient`. UI tests run separately via `xcodebuild`.
- Dependencies: the root `Package.swift` has no direct third-party dependencies; org packages track `branch: "main"`.
- Log stream snippet: touch `Sources/RunBot/App/RunBotDesktopApp.swift` (not the removed `AppDelegate.swift`).
- SwiftLint: broaden `file_header`; drop `large_tuple`; keep `sorted_imports` with `--strict`.
- Updates: document versioned states and that `checkAndHandle(state:)`/`scheduleBackgroundCheck(state:)` live in `runbot-hq/AppUpdater`; replace SHA-256 sidecar with Ed25519 signing (`RunBot.zip.sig`) and enforce signature verification before install, with browser fallback on failure.

<sup>Written for commit 18724077b2bebc9e5ff80185fb841531b6cebfb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bring deployment documentation in line with the current application architecture, CI workflow, and signed release update process.

Bug Fixes:
- Correct deployment documentation for current SwiftPM targets, test commands, dependency declarations, lint guidance, development launch behavior, and log-stream setup.
- Update release and in-app update documentation to describe Ed25519 archive signing and verification instead of outdated SHA-256 sidecars.
- Clarify the ownership and location of update functionality and document current update state and fallback behavior.

Enhancements:
- Align deployment instructions with the AppShell migration and AppUpdater extraction, including separate handling for SwiftPM and Xcode UI tests.

Documentation:
- Revise deployment documentation to accurately describe development targets, testing, linting, release publishing, and update installation workflows.