### PR TITLE
refactor(tests): replace fixture force-unwraps with diagnostic failures (#2998)

### DIFF
--- a/Tests/RunBotCoreTests/GitHub/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHub/GitHubHelpersTests.swift
@@ -62,45 +62,51 @@ final class GitHubHelpersTests: XCTestCase {
 
     /// Verifies stage-1 exact name matching: the step name must match the
     /// `##[group]` header directly, returning only the matched section.
-    func test_fallback_exactNameMatch() {
+    func test_fallback_exactNameMatch() throws {
         let raw = makeLog(sections: [
             (name: "Build", body: ["build output"]),
             (name: "Test",  body: ["test output"])
         ])
-        let result = parseStepLog(raw, stepName: "Build", stepNumber: 1, logger: nil)
-        XCTAssertNotNil(result, "Stage-1 exact match must find the section")
-        XCTAssert(result!.contains("build output"))
-        XCTAssertFalse(result!.contains("test output"),
+        let result = try XCTUnwrap(
+            parseStepLog(raw, stepName: "Build", stepNumber: 1, logger: nil),
+            "Stage-1 exact match must find the section"
+        )
+        XCTAssert(result.contains("build output"))
+        XCTAssertFalse(result.contains("test output"),
             "Only the matched section must be returned")
     }
 
     /// Verifies stage-2 `Run`-prefix normalisation: a step name without the
     /// `Run ` prefix must match a `##[group]` header that has it, and vice versa.
-    func test_fallback_runPrefixNormalisation() {
+    func test_fallback_runPrefixNormalisation() throws {
         let raw = makeLog(sections: [
             (name: "Run actions/checkout@v4", body: ["Fetching the repository"]),
             (name: "Run build",               body: ["unrelated build output"])
         ])
-        let result = parseStepLog(raw, stepName: "actions/checkout@v4", stepNumber: 2, logger: nil)
-        XCTAssertNotNil(result, "Run-prefix normalisation must bridge step name to ##[group] header")
-        XCTAssert(result!.contains("Fetching the repository"))
-        XCTAssertFalse(result!.contains("unrelated build output"),
+        let result = try XCTUnwrap(
+            parseStepLog(raw, stepName: "actions/checkout@v4", stepNumber: 2, logger: nil),
+            "Run-prefix normalisation must bridge step name to ##[group] header"
+        )
+        XCTAssert(result.contains("Fetching the repository"))
+        XCTAssertFalse(result.contains("unrelated build output"),
             "Run-prefix match must return only the matched section")
     }
 
     /// Verifies stage-3 synthetic-step epilogue heuristic: `Complete job` (which
     /// produces no `##[group]` markers in real logs) must be routed to the
     /// epilogue section, not return nil or the full log blob.
-    func test_fallback_completeJobEpilogueHeuristic() {
+    func test_fallback_completeJobEpilogueHeuristic() throws {
         let raw = makeLog(
             sections: [(name: "Run some-action", body: ["doing work"])],
             epilogue: ["Post job cleanup.", "Cleaning up orphan processes"]
         )
-        let result = parseStepLog(raw, stepName: "Complete job", stepNumber: 99, logger: nil)
-        XCTAssertNotNil(result, "Complete job must resolve to the epilogue section")
-        XCTAssert(result!.contains("Post job cleanup."),
+        let result = try XCTUnwrap(
+            parseStepLog(raw, stepName: "Complete job", stepNumber: 99, logger: nil),
+            "Complete job must resolve to the epilogue section"
+        )
+        XCTAssert(result.contains("Post job cleanup."),
             "Epilogue content must be returned for the synthetic Complete job step")
-        XCTAssertFalse(result!.contains("doing work"),
+        XCTAssertFalse(result.contains("doing work"),
             "Body of an unrelated section must not bleed into the epilogue result")
     }
 
@@ -108,22 +114,24 @@ final class GitHubHelpersTests: XCTestCase {
     /// differs only in casing from the `##[group]` header must still match.
     /// This path was a real prior regression — case-sensitive matching caused
     /// steps like "Set up job" (API) vs "set up job" (log header) to miss.
-    func test_fallback_exactNameMatch_caseInsensitive() {
+    func test_fallback_exactNameMatch_caseInsensitive() throws {
         let raw = makeLog(sections: [
             (name: "Set Up Job", body: ["runner provisioned"]),
             (name: "Build",      body: ["build output"])
         ])
-        let result = parseStepLog(raw, stepName: "set up job", stepNumber: 1, logger: nil)
-        XCTAssertNotNil(result, "Case-insensitive match must find the section")
-        XCTAssert(result!.contains("runner provisioned"))
-        XCTAssertFalse(result!.contains("build output"),
+        let result = try XCTUnwrap(
+            parseStepLog(raw, stepName: "set up job", stepNumber: 1, logger: nil),
+            "Case-insensitive match must find the section"
+        )
+        XCTAssert(result.contains("runner provisioned"))
+        XCTAssertFalse(result.contains("build output"),
             "Only the matched section must be returned")
     }
 
     /// Verifies that lines between `##[group]` blocks are not duplicated in the
     /// matched section. A prior regression caused inter-group orphan lines to
     /// be appended to the *next* matched section, inflating its output.
-    func test_fallback_interGroupLines_noDuplication() {
+    func test_fallback_interGroupLines_noDuplication() throws {
         // Raw log: orphan line lives between two groups.
         let orphanLine = "2026-01-01T00:00:00Z orphan line between groups"
         let raw = [
@@ -135,11 +143,11 @@ final class GitHubHelpersTests: XCTestCase {
             "2026-01-01T00:00:00Z test line",
             "2026-01-01T00:00:00Z ##[endgroup]"
         ].joined(separator: "\n")
-        let result = parseStepLog(raw, stepName: "Test", stepNumber: 2, logger: nil)
-        XCTAssertNotNil(result, "Test section must be found")
-        XCTAssertFalse(result!.contains("orphan line between groups"),
+        let result = try XCTUnwrap(parseStepLog(raw, stepName: "Test", stepNumber: 2, logger: nil),
+            "Test section must be found")
+        XCTAssertFalse(result.contains("orphan line between groups"),
             "Inter-group orphan lines must not bleed into the following section")
-        XCTAssert(result!.contains("test line"))
+        XCTAssert(result.contains("test line"))
     }
 
     /// Verifies that buildParsedLog ignores a stray `##[endgroup]` before the first
@@ -194,16 +202,15 @@ final class GitHubHelpersTests: XCTestCase {
     ///
     /// Since #2413, ANSI is no longer stripped at parse time — it passes through
     /// to the UI layer for rendering by `ansiAttributedString`.
-    func test_parseStepLog_ansiPassThrough() {
+    func test_parseStepLog_ansiPassThrough() throws {
         let esc = "\u{001B}"
         let raw = makeLog(sections: [
             (name: "Build", body: ["\(esc)[32mbuild output\(esc)[0m"])
         ])
-        let result = parseStepLog(raw, stepName: "Build", stepNumber: 1, logger: nil)
-        XCTAssertNotNil(result)
-        XCTAssert(result!.contains(esc),
+        let result = try XCTUnwrap(parseStepLog(raw, stepName: "Build", stepNumber: 1, logger: nil))
+        XCTAssert(result.contains(esc),
             "parseStepLog must preserve ANSI sequences — stripping happens at the render layer")
-        XCTAssert(result!.contains("build output"))
+        XCTAssert(result.contains("build output"))
     }
 
     // MARK: - cleanLogText pipeline

--- a/Tests/RunBotCoreTests/Runner/Models/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunBotCoreTests/Runner/Models/ActiveJobAsCompletedTests.swift
@@ -15,7 +15,10 @@ struct ActiveJobAsCompletedTests {
   /// ISO-8601 string used as an explicit completedAt in some fixtures.
   private static let knownDateString = "2024-01-15T10:30:00Z"
   private static let knownDate: Date = {
-    ISO8601DateFormatter().date(from: knownDateString)!
+    guard let date = ISO8601DateFormatter().date(from: knownDateString) else {
+      fatalError("Invalid knownDateString fixture: \(knownDateString)")
+    }
+    return date
   }()
 
   /// A fallback `Date` passed to `asCompleted(at:)`.

--- a/Tests/RunBotCoreTests/Runner/Polling/CompletedGroupZIPPrefetchTests.swift
+++ b/Tests/RunBotCoreTests/Runner/Polling/CompletedGroupZIPPrefetchTests.swift
@@ -128,6 +128,17 @@ final class CompletedGroupZIPPrefetchTests: XCTestCase {
 
     // MARK: - Factory
 
+    /// Creates an isolated UUID-namespaced `UserDefaults` suite for fixture
+    /// state. A failed suite initialisation must report the offending name
+    /// rather than crash on a bare force-unwrap.
+    private func makeDefaultsStore() -> UserDefaults {
+        let suiteName = UUID().uuidString
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Unable to create test UserDefaults suite: \(suiteName)")
+        }
+        return defaults
+    }
+
     @MainActor
     private func makePoller(transport: TestFakeTransport) -> RunnerPoller {
         let disk = DiskZIPCache(cacheDir: tempDir)
@@ -138,7 +149,7 @@ final class CompletedGroupZIPPrefetchTests: XCTestCase {
             scopeStore: StubScopeStore(),
             localRunners: { [] },
             applyMetrics: { _, _, _ in },
-            notificationPreferences: NotificationPreferences(store: UserDefaults(suiteName: UUID().uuidString)!),
+            notificationPreferences: NotificationPreferences(store: makeDefaultsStore()),
             diskZIPCache: disk,
             zipPrefetchQueue: queue
         )
@@ -320,7 +331,7 @@ final class CompletedGroupZIPPrefetchTests: XCTestCase {
             localRunners: { [] },
             applyMetrics: { _, _, _ in },
             notificationPreferences: NotificationPreferences(
-                store: UserDefaults(suiteName: UUID().uuidString)!),
+                store: makeDefaultsStore()),
             diskZIPCache: disk,
             zipPrefetchQueue: queue
         )
@@ -401,7 +412,7 @@ final class CompletedGroupZIPPrefetchTests: XCTestCase {
             localRunners: { [] },
             applyMetrics: { _, _, _ in },
             notificationPreferences: NotificationPreferences(
-                store: UserDefaults(suiteName: UUID().uuidString)!),
+                store: makeDefaultsStore()),
             zipPrefetchQueue: queue
         )
 

--- a/Tests/RunBotCoreTests/Runner/Stores/LocalRunnerIndexTests.swift
+++ b/Tests/RunBotCoreTests/Runner/Stores/LocalRunnerIndexTests.swift
@@ -24,7 +24,9 @@ struct LocalRunnerIndexTests {
   /// Callers are responsible for cleanup via `UserDefaults.standard.removePersistentDomain(forName:)`.
   private static func makeSuite() -> (UserDefaults, String) {
     let suiteName = "com.runbot.tests.LocalRunnerIndex.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suiteName)!
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      fatalError("Unable to create test UserDefaults suite: \(suiteName)")
+    }
     return (defaults, suiteName)
   }
 


### PR DESCRIPTION
Closes #2998 (DeepSource feedback triage, ref #2995)
Stacked on: fix-migrate-to-app-shell-step-30

Implements only the two finding groups the issue marks as worth fixing; explicitly rejects the rest per the issue's decision table. No production code changed — tests and fixtures only.

## Fixed

### 1. `result!` after `XCTAssertNotNil` → `XCTUnwrap` (findings 2–13)

The six `parseStepLog` fallback tests in `GitHub/GitHubHelpersTests.swift` now use `try XCTUnwrap(...)` carrying the former `XCTAssertNotNil` message, so a nil parse result fails once with a useful diagnostic instead of a secondary force-unwrap crash:

- `test_fallback_exactNameMatch`
- `test_fallback_runPrefixNormalisation`
- `test_fallback_completeJobEpilogueHeuristic`
- `test_fallback_exactNameMatch_caseInsensitive`
- `test_fallback_interGroupLines_noDuplication`
- `test_parseStepLog_ansiPassThrough`

### 2. Fixture construction force-unwraps → diagnostic guard failures

- `ActiveJobAsCompletedTests.knownDate`:
  ```swift
  guard let date = ISO8601DateFormatter().date(from: knownDateString) else {
      fatalError("Invalid knownDateString fixture: \(knownDateString)")
  }
  ```
- `LocalRunnerIndexTests.makeSuite()`:
  ```swift
  guard let defaults = UserDefaults(suiteName: suiteName) else {
      fatalError("Unable to create test UserDefaults suite: \(suiteName)")
  }
  ```
- `CompletedGroupZIPPrefetchTests`: three repeated `UserDefaults(suiteName: UUID().uuidString)!` constructions replaced by a file-local `makeDefaultsStore()` helper using the same guard/fatalError pattern (kept file-local as suggested).

## Rejected (per issue decision table)

| Finding group | Rule | Reason |
|---|---|---|
| Same-file extension (`RepoSelectorSheet`) | SW-R1028 | Intentional house style |
| Named multiline closure arguments | SW-R1004 | Previously rejected; conflicts with SwiftLint style |
| Test complexity (`makeGroup`, `directiveClassificationContract`, `groupStructureContract`) | SW-R1002 | Intentionally consolidated; complexity is fixture construction |
| XCTest `tempDir: URL!` | SW-W1022 | Standard setUp/teardown fixture pattern |

No extension, closure-style, complexity, or XCTest fixture-property changes were made.

## Validation

- `swift build` ✅ · `swift test` ✅ **118 tests / 27 suites (unchanged)**
- `swiftlint lint --strict` ✅ 0 violations


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces force-unwraps in tests and fixtures with diagnostic failures to improve failure messages and avoid secondary crashes. Old behavior used `XCTAssertNotNil` followed by `result!` and `!` in fixtures; new behavior uses `XCTUnwrap` and guard+fatalError. No production code changed.

- Switch six `parseStepLog` fallback tests to `try XCTUnwrap(...)`, preserving the original assertion messages.
- Replace fixture force-unwraps: guard-fail ISO-8601 date parsing and `UserDefaults(suiteName:)`; add a file-local `makeDefaultsStore()` helper in `CompletedGroupZIPPrefetchTests`.
- Explicitly out of scope per prior decision: same-file extensions, named multiline closure args, consolidated test complexity, and the `tempDir: URL!` XCTest fixture pattern.

<sup>Written for commit 33abc23d65223be8468ab9e9e2194a651daffc6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/3001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Improve test failure diagnostics by removing force unwraps from assertions and fixture construction.

Bug Fixes:
- Replace force-unwrap-based test assertions and fixture setup with diagnostic failures that report actionable error messages.

Enhancements:
- Use XCTUnwrap for parse-step test results and guarded initialization for date and UserDefaults fixtures.

Tests:
- Update test fixtures and assertions without changing production behavior or test coverage.