### PR TITLE
refactor(core): move WorkflowSelection into RunBotCore and drop RunBotTests target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,13 +90,5 @@ let package = Package(
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault")
             ]
         ),
-        .testTarget(
-            name: "RunBotTests",
-            dependencies: ["RunBot"],
-            path: "Tests/RunBotTests",
-            swiftSettings: [
-                .enableUpcomingFeature("NonisolatedNonsendingByDefault")
-            ]
-        ),
     ]
 )

--- a/Sources/RunBotCore/State/WorkflowSelection.swift
+++ b/Sources/RunBotCore/State/WorkflowSelection.swift
@@ -1,8 +1,7 @@
 // WorkflowSelection.swift
-// RunBot
+// RunBotCore
 
 import Observation
-import RunBotCore
 
 /// In-memory selection state for the workflow hierarchy and step-log detail.
 ///
@@ -11,30 +10,33 @@ import RunBotCore
 /// No persistence, stores, or runtime integration.
 @MainActor
 @Observable
-final class WorkflowSelection {
+public final class WorkflowSelection {
 
     /// Selected `WorkflowActionGroup` identifier.
-    var workflowID: String?
+    public var workflowID: String?
     /// Selected `ActiveJob` identifier (raw GitHub job ID).
-    var jobID: Int?
+    public var jobID: Int?
     /// Selected step identifier — 1-based `GitHubStep.number` within the job.
-    var stepNumber: Int?
+    public var stepNumber: Int?
+
+    /// Creates an empty selection state.
+    public init() {}
 
     /// Selects a workflow and clears downstream job/step selection.
-    func selectWorkflow(_ id: String?) {
+    public func selectWorkflow(_ id: String?) {
         workflowID = id
         jobID = nil
         stepNumber = nil
     }
 
     /// Selects a job and clears downstream step selection.
-    func selectJob(_ id: Int?) {
+    public func selectJob(_ id: Int?) {
         jobID = id
         stepNumber = nil
     }
 
     /// Selects a step.
-    func selectStep(_ number: Int?) {
+    public func selectStep(_ number: Int?) {
         stepNumber = number
     }
 
@@ -43,7 +45,7 @@ final class WorkflowSelection {
     /// Hierarchy rows stay visible for workflows other than the selected one,
     /// so the full path must be set on tap. Keeps the current step selection
     /// when the job is unchanged (e.g. a collapse tap); clears it otherwise.
-    func selectJob(_ id: Int, inWorkflow workflowID: String) {
+    public func selectJob(_ id: Int, inWorkflow workflowID: String) {
         self.workflowID = workflowID
         if jobID != id { stepNumber = nil }
         jobID = id
@@ -53,7 +55,7 @@ final class WorkflowSelection {
     ///
     /// Sets the full path so a step tap in any expanded workflow shows the
     /// correct log, even when a different workflow or job was selected before.
-    func selectStep(_ number: Int, ofJob jobID: Int, inWorkflow workflowID: String) {
+    public func selectStep(_ number: Int, ofJob jobID: Int, inWorkflow workflowID: String) {
         self.workflowID = workflowID
         self.jobID = jobID
         stepNumber = number
@@ -63,7 +65,7 @@ final class WorkflowSelection {
     ///
     /// Call after the workflow list is refreshed so stale selections do not
     /// silently point at removed items.
-    func reconcile(workflows: [WorkflowActionGroup]) {
+    public func reconcile(workflows: [WorkflowActionGroup]) {
         guard let wid = workflowID else { return }
         guard let workflow = workflows.first(where: { $0.id == wid }) else {
             selectWorkflow(nil)

--- a/Tests/RunBotCoreTests/State/WorkflowSelectionTests.swift
+++ b/Tests/RunBotCoreTests/State/WorkflowSelectionTests.swift
@@ -1,8 +1,8 @@
 // WorkflowSelectionTests.swift
-// RunBotTests
+// RunBotCore
 
 import Testing
-@testable import RunBot
+@testable import RunBotCore
 
 /// Smoke test — just enough to confirm WorkflowSelection exists and basic
 /// select/clear round-trips work. Detailed reconcile behaviour is intentionally


### PR DESCRIPTION
Stacked on #2999's branch (`fix-migrate-to-app-shell-step-31`). Closes #3000.

## Context

#3000 asked to move `MainHierarchyState` into RunBotCore and remove the one-off `RunBotTests` target. `MainHierarchyState` (and the legacy panel layer it belonged to) was already deleted in 59fb6ebff, but the underlying problem still existed in the same shape: `RunBotTests` was an entire app-target unit-test target existing solely for `WorkflowSelectionTests`, testing `WorkflowSelection` — an `@Observable` state class in the app target that depends only on `Observation` and Core types. This PR applies the issue's prescribed fix to that class.

## Changes

- **Move implementation:** `Sources/RunBot/Features/Workflows/WorkflowSelection.swift` → `Sources/RunBotCore/State/WorkflowSelection.swift`; removed `import RunBotCore`
- **Access control:** class + all consumed surface (`init`, three stored properties, all five selection methods, `reconcile(workflows:)`) marked `public`; no internal storage was exposed beyond what app call sites (`AppShellView`, `AppContentView`, `AppDetailView`, `WorkflowHierarchyView`) already used
- **Move tests:** `WorkflowSelectionTests` → `Tests/RunBotCoreTests/State/`, switched to `@testable import RunBotCore`; tests unchanged
- **Package:** removed the `RunBotTests` test target from `Package.swift`; deleted now-empty `Tests/RunBotTests/`

## Validation

- `swift build` ✅
- `swift test --filter WorkflowSelectionTests` — 4/4 pass ✅
- `swift test` — 118 tests, 27 suites, all pass ✅
- `swiftlint lint --strict` — 0 violations ✅
- `periphery scan` — clean ✅
- `rg 'RunBotTests|@testable import RunBot' Package.swift Tests Sources` — no matches ✅

No UI-test target changes; behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `WorkflowSelection` from the app to `RunBotCore` and removes the app-only `RunBotTests` target to satisfy #3000. The type is now `public`; runtime behavior is unchanged.

- Implementation moved to `Sources/RunBotCore/State/WorkflowSelection.swift` and marked `public` where consumed; tests moved to `Tests/RunBotCoreTests/State/` with `@testable import RunBotCore`.
- Removed `RunBotTests` test target from `Package.swift` and deleted its directory.
- Migration: If any code referenced `WorkflowSelection` via `RunBot`, import `RunBotCore` instead; no call-site changes required.

<sup>Written for commit cb3a4c024451fdc74537ea368ffa9a98c89e92e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/3002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Move workflow selection state and its tests into RunBotCore, and remove the redundant app-only test target.

Enhancements:
- Move WorkflowSelection into RunBotCore as a publicly accessible workflow selection state model.

Build:
- Remove the dedicated RunBotTests test target and its now-empty test directory.

Tests:
- Relocate WorkflowSelectionTests to RunBotCoreTests while preserving the existing test coverage.