### PR TITLE
docs(app): correct stale AppDelegate comments [skip ai review]

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -14,7 +14,8 @@ import SwiftUI
 // that now.
 //
 // As of the anchored-panel rewrite there is no NSPopover anywhere in the app.
-// MenuBarKit owns one borderless NSPanel and draws the bubble and arrow itself.
+// MenuBarKit owns one borderless NSPanel and its Liquid Glass surface.
+// It does not use NSPopover or an anchor arrow.
 //
 // As of #2264 the root view is RootPanelView — a single persistent view that
 // owns all route switching via Group { switch }.id(route). This replaces the
@@ -105,20 +106,11 @@ extension AppDelegate {
             maxHeightFraction: AppDelegate.panelHeightMultiplier
         )
 
-        // onWillShow is intentionally empty / commented out.
+        // No onWillShow callback is required.
         //
-        // WHY nav state does not need to be restored here:
-        // appState.savedNavState is persistent @Observable state. Panel dismissal
-        // does not clear it; only explicit back-navigation changes the route.
-        // RootPanelView reads it directly and reactively, so the SwiftUI tree is
-        // already rendering the saved route before the panel becomes visible.
-        //
-        // Other candidates considered for this callback (auth token pre-flight, stale-job
-        // guard restoration) were deferred — see the commented-out block below for context.
-        // Do not remove; restore and expand once onWillShow responsibilities are decided.
-        // ctrl.onWillShow = {
-        //     log("AppDelegate › onWillShow")
-        // }
+        // Navigation state is persistent observable state owned by AppState.
+        // Panel dismissal does not clear it, and RootPanelView reads it
+        // reactively before the panel becomes visible.
 
         // onDidShow — fires one actor turn after openPanel().
         // Restore runner sheet state now that the view tree has a window.

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -79,10 +79,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///    have been migrated to AppState. Use `appState.x` instead.
     let appState = AppState()
 
-    /// Gate that tracks whether a sheet or file-picker overlay is active.
+    /// Gate tracking whether a sheet, file picker, or alert is active.
+    ///
     /// Injected into the SwiftUI view tree by `RootEnvView`, which is created
-    /// in `setupPanel()`. Views use `.mbkSheet(overlayGate:)` and
-    /// `mbkOpenFilePicker()` to arm this gate for the overlay lifetime.
+    /// in `setupPanel()`. `.mbkSheet` and `.mbkAlert` manage the environment
+    /// gate automatically; `mbkOpenFilePicker(overlayGate:)` receives the same
+    /// gate explicitly because it is a free function.
     let overlayGate = MBKOverlayGate()
 
     /// Panel controller handle injected into the SwiftUI environment.
@@ -91,8 +93,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// controller only when a view later requests remeasurement.
     var panelControllerHandle: PanelControllerHandle?
 
-    /// Owns the panel lifecycle: status item, anchored NSPanel, arrow placement,
-    /// size tracking, outside-click monitor, workspace observer.
+    /// Owns the panel lifecycle: status item, anchored NSPanel, size tracking,
+    /// outside-click monitor, and workspace observer.
     /// Replaced NSPopover + KVO as of #2262.
     var panelController: MBKPanelController<RootEnvView>!
 

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -10,10 +10,11 @@ import SwiftUI
 //
 // As of #2262, NSPopover + PopoverLifecycleCoordinator + KVO are replaced by
 // MBKPanelController. As of the anchored-panel rewrite there is no NSPopover
-// anywhere in the app: MenuBarKit owns one borderless NSPanel and draws the
-// bubble and arrow itself. The panel lifecycle (open, close, force-close,
-// outside-click monitor, workspace observer, arrow placement, size tracking)
-// is fully owned by MBKPanelController from MenuBarKit.
+// anywhere in the app: MenuBarKit owns one borderless NSPanel and its Liquid
+// Glass surface. It does not use NSPopover or an anchor arrow. The panel
+// lifecycle (open, close, force-close, outside-click monitor, workspace
+// observer, size tracking) is fully owned by MBKPanelController from
+// MenuBarKit.
 //
 // Run-bot's responsibilities are:
 //   1. Wire onWillShow / onDidShow / onWillClose callbacks.
@@ -30,8 +31,10 @@ import SwiftUI
 //
 // PANELVISIBILITYSTATE:
 // panelVisibilityState.isOpen is set in onWillClose (false) and onDidShow (true).
-// ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
-// See ARCHITECTURE.md §panelVisibilityState.
+// Injected through RootEnvView. Do not remove from the environment chain
+// while the MenuBarKit panel shell remains active.
+// See PanelContainerView and AppDelegate+PanelSetup for the panel
+// visibility-state lifecycle.
 
 /// Environment-injectable handle for remeasuring the panel when SwiftUI content grows.
 ///
@@ -40,15 +43,15 @@ import SwiftUI
 /// a plain `final class` and cannot be made `@Observable` from outside the
 /// `MenuBarKit` module, so this wrapper bridges the gap.
 ///
-/// The `panelController` reference is weak to avoid a retain cycle — the
-/// controller owns the panel which owns the hosting view which owns the SwiftUI
-/// tree that holds this handle.
+/// The handle stores an injected closure rather than the panel controller
+/// itself. The production closure captures AppDelegate weakly, avoiding a
+/// retain cycle through the controller, hosting view, and SwiftUI environment.
 @MainActor
 @Observable
 final class PanelControllerHandle {
-    /// Calls `MBKPanelController.invalidateContentSize()` via the weak reference
-    /// captured at construction time. Safe to call while the panel is closed —
-    /// the measurement is skipped by `applyMeasuredSize`'s `isShown` guard.
+    /// Requests `MBKPanelController.invalidateContentSize()` through the
+    /// injected closure. Safe while the panel is closed: the measurement is
+    /// skipped by `applyMeasuredSize`'s `isShown` guard.
     let remeasure: () -> Void
 
     /// Creates a handle with the given remeasure closure.
@@ -77,15 +80,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let appState = AppState()
 
     /// Gate that tracks whether a sheet or file-picker overlay is active.
-    /// Injected into the SwiftUI view tree via `.environment(overlayGate)` in
-    /// `wrapEnv(_:)`. Views use `.mbkSheet(overlayGate:)` and
+    /// Injected into the SwiftUI view tree by `RootEnvView`, which is created
+    /// in `setupPanel()`. Views use `.mbkSheet(overlayGate:)` and
     /// `mbkOpenFilePicker()` to arm this gate for the overlay lifetime.
     let overlayGate = MBKOverlayGate()
 
     /// Panel controller handle injected into the SwiftUI environment.
-    /// Created after `panelController` is assigned so the remeasure closure
-    /// captures a non-nil reference. Updated in `setupPanel()` after the
-    /// controller is created.
+    /// Assigned during `setupPanel()`. The handle itself is constructed before
+    /// `panelController` is assigned; its weakly capturing closure resolves the
+    /// controller only when a view later requests remeasurement.
     var panelControllerHandle: PanelControllerHandle?
 
     /// Owns the panel lifecycle: status item, anchored NSPanel, arrow placement,
@@ -98,8 +101,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let panelSheetState = PanelSheetState()
 
     /// Shared observable that tracks whether the panel is open.
-    /// Injected into every SwiftUI view via `wrapEnv(_:)`
-    /// ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
+    /// Injected through RootEnvView. Do not remove from the environment chain
+    /// while the MenuBarKit panel shell remains active.
     let panelVisibilityState = PanelVisibilityState()
 
     // MARK: - Environment injection (removed)

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -22,10 +22,10 @@ import RunBotCore
 //    PanelSheetState, or any AppKit wiring. Those stay on AppDelegate.
 //
 // LAYERING:
-// AppState lives in the RunBot app target. It may import RunBotCore,
-// GitHubClient, and AppUpdater. It must NOT import MenuBarKit — that
-// would create a circular dependency (MBKOverlayGate is AppDelegate-owned
-// specifically to honour this constraint).
+// AppState lives in the RunBot app target and may import RunBotCore,
+// GitHubClient, and AppUpdater. It deliberately does not import MenuBarKit:
+// panel, overlay, and window lifecycle belong to AppDelegate composition,
+// not to the domain coordinator.
 //
 // WHY NOT AppStateProtocol?
 // SettingsView previously accepted protocol-typed service parameters so tests
@@ -137,9 +137,8 @@ final class AppState {
     ///
     /// Created here (not inside `start()`) so it survives for the full app
     /// lifetime. `RunnerPoller.applyFetchResult` writes into this instance on
-    /// the `@MainActor` after every poll cycle. Views read from it via
-    /// Views read from it by declaring `@Environment(AppState.self) var appState`
-    /// and accessing `appState.runnerState`.
+    /// the `@MainActor` after every poll cycle. Views read it through
+    /// `@Environment(AppState.self)` and access `appState.runnerState`.
     let runnerState = RunnerState()
 
     /// Auto-update driver. Injected into `SettingsView` for the
@@ -208,8 +207,9 @@ final class AppState {
     /// Shared `LogFetcher` instance owned above the `.id(navState)` boundary
     /// in `RootPanelView`. Owning it here means the ZIP cache (`zipCache`)
     /// survives across step-tap navigation: every step tap recreates
-    /// `StepLogView`, but `AppState` is not remounted, so the cache persists
-    /// for the lifetime of the panel session.
+    /// `StepLogView`, but `AppState` is not remounted, so the cache persists.
+    /// The instance lives for the AppState/process lifetime and survives
+    /// repeated panel close/reopen cycles.
     ///
     /// ⚠️ Must be constructed after `github` so the transport is already wired.
     var logFetcher: LogFetcher
@@ -224,7 +224,9 @@ final class AppState {
     // closePanel() and the settings-back callback — both AppKit-level wiring
     // events, not domain events. Co-locating it with popover lifecycle is cleaner.
 
-    /// Write-only task handle — the assignment keeps the Task alive (ARC).
+    /// Retained task handle used for explicit cancellation during AppState
+    /// teardown. The task executes independently of handle retention; storing
+    /// the handle provides lifecycle control.
     /// `@ObservationIgnored`: never read externally, no-op registrar calls.
     /// `nonisolated(unsafe)`: lets `deinit` call `.cancel()` safely; Task.cancel()
     /// is thread-safe and writes only happen on @MainActor in startObservations().
@@ -393,8 +395,9 @@ final class AppState {
 
         // Step 0: seed GitHubAuthentication from live credential stores on cold launch.
         // OAuth sync is synchronous so there is no `.signedOut` flash before the poll
-        // loop starts (Step 4). Env discovery runs in a detached Task (login-shell
-        // probe can take ~50–200ms). syncOAuthState — NOT recordOAuthSignIn — so the
+        // loop starts (Step 4). Env discovery runs in a separate unstructured MainActor
+        // task so startup does not wait for the login-shell probe (which can take
+        // ~50–200ms). syncOAuthState — NOT recordOAuthSignIn — so the
         // persisted `selectedSource` is never overwritten here (fix for #2464).
         authentication.syncOAuthState(isAuthenticated: oauthService.isAuthenticated)
         Task { @MainActor [authentication, github] in
@@ -432,20 +435,19 @@ final class AppState {
         }
 
         // Step 4: start the poll loop.
-        // On a cold Finder/Dock/login-item launch, the first poll cycle's token()
-        // call suspends here for ~50–200 ms while the login shell sources
-        // ~/.zprofile and ~/.zshrc to recover GH_TOKEN. The result is cached;
+        // RunnerPoller.start() installs the poll task and returns. The poll task's
+        // initial fetch may spend ~50–200 ms resolving a login-shell token on a
+        // cold Finder/Dock/login-item launch (the shell sources ~/.zprofile and
+        // ~/.zshrc to recover GH_TOKEN). The resolved token is then cached;
         // all subsequent poll cycles return immediately from the in-memory cache.
         // Terminal, CI, and Keychain OAuth launches resolve from ProcessInfo or
         // Keychain and do not spawn a shell.
         await store.start()
         log("AppState › start — poll loop started")
 
-        // Seed autoUpdater flag from user preference (#2501).
-        // Must run after Step 4 (store.start()) so UserDefaults is fully
-        // initialised. Placed here rather than at AppUpdater init time because
-        // AppPreferencesStore.shared is a @MainActor singleton whose value is
-        // stable only after the app's main-actor startup sequence begins.
+        // Seed AppUpdater's runtime gate from the persisted preference (#2501)
+        // before performing the launch-time update check and registering the
+        // scheduler.
         autoUpdater.automaticUpdatesEnabled = AppPreferencesStore.shared.automaticUpdatesEnabled
         log("AppState › start — autoUpdater.automaticUpdatesEnabled=\(autoUpdater.automaticUpdatesEnabled)")
 

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -30,8 +30,9 @@ import RunBotCore
 // WHY NOT AppStateProtocol?
 // SettingsView previously accepted protocol-typed service parameters so tests
 // could inject stubs. With AppState as the single injection point, tests must
-// construct a full AppState — an accepted trade-off since AppState's concrete
-// types have no side effects at init time (tracked as migration debt in wrapEnv).
+// construct a full AppState directly. This remains an accepted trade-off while
+// its dependencies are initialization-safe and perform no network or process
+// work during construction.
 //
 // THREADING:
 // @MainActor-isolated. Domain sub-objects that write observable state hop
@@ -49,9 +50,8 @@ import RunBotCore
 
 /// Coordinator for all domain-level state owned by the RunBot app process.
 ///
-/// Injected into the SwiftUI environment as a single `.environment(appState)`
-/// call inside `AppDelegate.wrapEnv(_:)`. Views access sub-objects via
-/// `@Environment(AppState.self)`.
+/// Injected into the SwiftUI environment by `RootEnvView`.
+/// Views access domain state through `@Environment(AppState.self)`.
 @Observable
 @MainActor
 final class AppState {

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -68,9 +68,9 @@ import SwiftUI
 //         MEASURE passes (stale fittingSize open → settled onGeometryChange resize),
 //         SwiftUI re-centres the VStack in the new space instead of keeping it at the top.
 //
-// The panel's Liquid Glass bubble and arrow are drawn by MenuBarKit in AppKit
-// (`MBKPanelChromeView`: an NSGlassEffectView body plus a rotated NSGlassEffectView
-// arrow), one layer *below* this view —
+// The panel's Liquid Glass surface is owned by MenuBarKit in AppKit
+// (`NSGlassEffectView` set directly as the panel's contentView), one layer
+// *below* this view —
 // exactly where NSPopover used to put its chrome. That is deliberate: a SwiftUI
 // `.glassEffect` ancestor flattens every GlassEffectContainer in this file (the
 // metric bars, the SUCCESS/FAILED tags, every chip), which is what happened on
@@ -87,9 +87,9 @@ struct PanelMainView: View {
     var localRunnerStore: LocalRunnerStore = .shared
     /// Panel open/close and transient-hide state from the environment.
     @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
-    /// Core runner/job/action/rate-limit state injected from AppDelegate.wrapEnv.
+    /// Core runner/job/action/rate-limit state injected by RootEnvView.
     @Environment(AppState.self) private var appState
-    /// Panel controller handle injected from AppDelegate.wrapEnv — used to
+    /// Panel controller handle injected by RootEnvView — used to
     /// invalidate content size when the list grows and standard KVO is insufficient.
     @Environment(PanelControllerHandle.self) private var panelControllerHandle
     /// View model for CPU/GPU/memory stats displayed in the header.


### PR DESCRIPTION
Closes #3011. Brief: #3010.

## Context
The task requires basing this work on `main`, since the AppDelegate/MenuBarKit surface no longer exists on the app-shell stack branches (verified: `fix-migrate-to-app-shell-step-35` has none of these files). This PR is therefore cut from `main` per the handoff.

## Changes (comment-only, 4 files)

**`AppDelegate.swift`**
- Header + `panelVisibilityState`: active `wrapEnv()` references replaced with the actual injection path (`RootEnvView`, created in `setupPanel()`); dropped "arrow placement" from MBK's owned-lifecycle list
- Removed deleted `ARCHITECTURE.md §panelVisibilityState` reference → source-local pointer to `PanelContainerView` + `AppDelegate+PanelSetup` (the `§@MainActor isolation` reference was verified valid in `docs/architecture.md` and kept)
- `PanelControllerHandle`: now described as storing an injected closure whose production construction captures AppDelegate weakly — not a stored weak controller reference; `remeasure` doc keeps the `applyMeasuredSize` `isShown` guard knowledge
- `panelControllerHandle` property: corrected to say the handle is constructed *before* `panelController` is assigned, with the weak closure resolving later
- `overlayGate`: injection path updated to `RootEnvView`

**`AppDelegate+PanelSetup.swift`**
- "draws the bubble and arrow itself" → "owns one borderless NSPanel and its Liquid Glass surface. It does not use NSPopover or an anchor arrow."
- Dormant commented-out `onWillShow` block condensed to concise rationale; `onDidShow`/`onWillClose` untouched

**`AppState.swift`**
- Environment-injection doc now names `RootEnvView`
- "no side effects at init time (tracked as migration debt in wrapEnv)" → narrower verified invariant: dependencies perform no network or process work during construction

**`PanelMainView.swift`**
- Both `AppDelegate.wrapEnv` property docs → "injected by RootEnvView"
- Fixed demonstrably false chrome description: `MBKPanelChromeView` does not exist in MenuBarKit and there is no arrow; replaced with verified layering (`NSGlassEffectView` set directly as panel `contentView`). The load-bearing "do not add .background()/.glassEffect()/NSVisualEffectView" invariant is preserved

## Explicitly untouched
`AppDelegate+Navigation`, `+OAuthCallback`, `+StatusItem`, `+StoreSetup`, `MainHierarchyState`, `RootEnvView` (its historical "replaces wrapEnv" statement remains), all executable code, tests, docs.

## Validation
- Diff audit: every changed line starts with `//` or `///` — zero executable-token changes ✅
- `rg 'AppDelegate\.wrapEnv|from wrapEnv|inside ``AppDelegate.wrapEnv'`` in App/ + PanelMainView.swift — no matches ✅
- `rg 'bubble and arrow|ARCHITECTURE.md §panelVisibilityState'` in App/ — no matches ✅
- `swift build` ✅ · `swift test` (338 tests, 40 suites) ✅ · `swiftlint lint --strict` (0 violations, 148 files) ✅ · `periphery scan` clean ✅

## Summary by Sourcery

Update application comments to reflect the current panel architecture and environment-injection design.

Enhancements:
- Refresh stale AppDelegate, AppState, panel setup, and panel view comments to accurately describe current environment injection, panel ownership, lifecycle behavior, and state management.

Documentation:
- Correct outdated architecture and implementation comments, including removed NSPopover/arrow references and obsolete wrapEnv documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer-facing documentation to reflect the app’s current anchored panel and Liquid Glass presentation.
  * Clarified that navigation state remains persistent and responds reactively.
  * Documented the current environment injection and panel visibility lifecycle.
  * Removed outdated references to popover arrows, obsolete callbacks, and previous setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->