### PR TITLE
refactor(app): rename AppShell files to match their routing roles (#3017)

### DIFF
--- a/Sources/RunBot/App/RunBotApp.swift
+++ b/Sources/RunBot/App/RunBotApp.swift
@@ -1,4 +1,4 @@
-// RunBotDesktopApp.swift
+// RunBotApp.swift
 // RunBot
 
 import GitHubClient
@@ -6,28 +6,28 @@ import RunBotCore
 import SwiftUI
 
 // @main removed: Sources/RunBot/main.swift is top-level code.
-// RunBotDesktopApp.main() is called from main.swift instead.
+// RunBotApp.main() is called from main.swift instead.
 
 /// The SwiftUI application entry point for RunBot.
 /// `@main` is intentionally absent because `main.swift` invokes `main()`.
-struct RunBotDesktopApp: App {
+struct RunBotApp: App {
     /// Authentication state owned at the window level and injected into the view hierarchy.
     @State private var authentication: GitHubAuthentication
-    /// Runner dependencies configured synchronously before any view is mounted.
-    /// `LocalRunnerStore.configure` runs inside `AppDependencies.init()`.
+    /// Long-lived domain runtime configured synchronously before any view is mounted.
+    /// `LocalRunnerStore.configure` runs inside `RunBotRuntime.init()`.
     /// Constructed in `init()` so it shares the same `authentication` instance.
-    @State private var deps: AppDependencies
+    @State private var runtime: RunBotRuntime
     /// App-owned log fetcher so the ZIP cache survives navigation and view
-    /// remounts. Created here (not in `AppDependencies`) because its
+    /// remounts. Created here (not in `RunBotRuntime`) because its
     /// lifetime is tied to the scene, threaded into `AppNavigationSplitView` via
     /// `$logFetcher`.
     @State private var logFetcher: LogFetcher
 
-    /// Initialises shared authentication and dependency bundle before first render.
+    /// Initialises shared authentication and the domain runtime before first render.
     init() {
         let auth = GitHubAuthentication()
         _authentication = State(initialValue: auth)
-        _deps = State(initialValue: AppDependencies(
+        _runtime = State(initialValue: RunBotRuntime(
             authentication: auth,
             onSignIn: {
                 // OAuthCredentialController lives in GitHubClient; sign-in UI is
@@ -45,21 +45,21 @@ struct RunBotDesktopApp: App {
     var body: some Scene {
         Window("RunBot", id: "main") {
             AppNavigationSplitView(
-                runnerState: deps.runnerState,
-                localRunnerStore: deps.localRunnerStore,
-                settingsDependencies: deps.settingsDependencies,
+                runnerState: runtime.runnerState,
+                localRunnerStore: runtime.localRunnerStore,
+                settingsDependencies: runtime.settingsDependencies,
                 logFetcher: $logFetcher
             )
             .environment(authentication)
             .task {
-                await deps.start()
+                await runtime.start()
             }
             .onOpenURL { url in
                 guard
                     url.scheme == GitHubConstants.oauthScheme,
                     url.host == GitHubConstants.oauthHost
                 else { return }
-                deps.handleOAuthCallback(url)
+                runtime.handleOAuthCallback(url)
             }
         }
         .windowStyle(.hiddenTitleBar)

--- a/Sources/RunBot/App/RunBotDesktopApp.swift
+++ b/Sources/RunBot/App/RunBotDesktopApp.swift
@@ -19,7 +19,7 @@ struct RunBotDesktopApp: App {
     @State private var deps: AppDependencies
     /// App-owned log fetcher so the ZIP cache survives navigation and view
     /// remounts. Created here (not in `AppDependencies`) because its
-    /// lifetime is tied to the scene, threaded into `AppShellView` via
+    /// lifetime is tied to the scene, threaded into `AppNavigationSplitView` via
     /// `$logFetcher`.
     @State private var logFetcher: LogFetcher
 
@@ -44,7 +44,7 @@ struct RunBotDesktopApp: App {
     /// The scene graph for the windowed application.
     var body: some Scene {
         Window("RunBot", id: "main") {
-            AppShellView(
+            AppNavigationSplitView(
                 runnerState: deps.runnerState,
                 localRunnerStore: deps.localRunnerStore,
                 settingsDependencies: deps.settingsDependencies,

--- a/Sources/RunBot/App/RunBotRuntime.swift
+++ b/Sources/RunBot/App/RunBotRuntime.swift
@@ -1,4 +1,4 @@
-// AppDependencies.swift
+// RunBotRuntime.swift
 // RunBot
 import AppKit
 import AppUpdater
@@ -7,9 +7,9 @@ import GitHubClient
 import Observation
 import RunBotCore
 
-// MARK: - AppDependencies
+// MARK: - RunBotRuntime
 
-/// Owns and configures the minimum domain dependencies required by the windowed app.
+/// Owns and configures the long-lived domain services required by the windowed app.
 ///
 /// `LocalRunnerStore.configure(viewModel:)` must be the very first call,
 /// synchronously, before any view is mounted. This mirrors the ordering rule
@@ -23,7 +23,7 @@ import RunBotCore
 ///   runnerStore.start             <- begins poll loop
 @MainActor
 @Observable
-final class AppDependencies {
+final class RunBotRuntime {
     /// Live runner state tree shared across all views in the windowed app.
     let runnerState: RunnerState
     /// Store that manages local (self-hosted) runner registration and refresh.
@@ -42,7 +42,7 @@ final class AppDependencies {
     /// Guards against duplicate `start()` calls (SwiftUI `.task` can fire more than once).
     private var didStart = false
 
-    /// Creates the dependency graph for the windowed app shell.
+    /// Creates the domain runtime for the windowed app shell.
     /// - Parameters:
     ///   - authentication: GitHub authentication controller.
     ///   - onSignIn: Closure called on the main actor after a successful sign-in.
@@ -137,7 +137,7 @@ final class AppDependencies {
 // MARK: - OAuth callback
 
 /// OAuth callback handling for the windowed SwiftUI lifecycle.
-extension AppDependencies {
+extension RunBotRuntime {
     /// Forwards a macOS open-URL event to the OAuth service so the
     /// authorization code can be exchanged for a token.
     ///
@@ -152,8 +152,8 @@ extension AppDependencies {
 
 // MARK: - Startup
 
-/// Startup lifecycle for `AppDependencies`.
-extension AppDependencies {
+/// Startup lifecycle for `RunBotRuntime`.
+extension RunBotRuntime {
     /// Starts the domain pipeline: credential reconcile -> local refresh -> poll loop.
     ///
     /// Idempotent - SwiftUI may recreate the root .task; subsequent calls are no-ops.

--- a/Sources/RunBot/App/main.swift
+++ b/Sources/RunBot/App/main.swift
@@ -1,7 +1,7 @@
 // main.swift
 // RunBot
 /// Entry point for the SwiftUI windowed application.
-/// `RunBotDesktopApp.main()` is called explicitly because `@main` cannot
+/// `RunBotApp.main()` is called explicitly because `@main` cannot
 /// coexist with top-level code in `main.swift`.
 /// ❌ NEVER remove the MainActor.assumeIsolated wrapper — the OS always
 /// starts on the main thread and this satisfies strict-concurrency checking.
@@ -13,5 +13,5 @@ import SwiftUI
 #endif
 
 MainActor.assumeIsolated {
-    RunBotDesktopApp.main()
+    RunBotApp.main()
 }

--- a/Sources/RunBot/AppShell/AppContentColumnView.swift
+++ b/Sources/RunBot/AppShell/AppContentColumnView.swift
@@ -1,4 +1,4 @@
-// AppContentView.swift
+// AppContentColumnView.swift
 // RunBot
 
 import GitHubClient
@@ -7,25 +7,25 @@ import SwiftUI
 
 /// Content-column router. Switches on the current sidebar selection.
 ///
-/// Workflows shows the workflow hierarchy (issue #2880); the other sections
+/// Workflows shows the workflow hierarchy (issue #2880); the other destinations
 /// host their existing self-contained feature roots. The `nil` case is
 /// defensive; Workflows is always selected on launch.
-struct AppContentView: View {
-    /// The currently selected sidebar section.
-    let selection: AppSection?
+struct AppContentColumnView: View {
+    /// The currently selected sidebar destination.
+    let selection: AppDestination?
 
     /// Observable runner state pushed by `LocalRunnerStore`.
     let runnerState: RunnerState
     /// Configured local-runner store forwarded from the composition root.
     let localRunnerStore: LocalRunnerStore
-    /// Shared workflow → job → step selection owned by `AppShellView`.
+    /// Shared workflow → job → step selection owned by `AppNavigationSplitView`.
     var workflowSelection: WorkflowSelection
 
-    /// Shared settings section selection owned by `AppShellView`.
+    /// Shared settings section selection owned by `AppNavigationSplitView`.
     @Binding var settingsSelection: SettingsSection?
-    /// Shared runner selection owned by `AppShellView`. (#2900)
+    /// Shared runner selection owned by `AppNavigationSplitView`. (#2900)
     @Binding var selectedRunnerID: RunnerModel.ID?
-    /// Shared scope selection owned by `AppShellView`. (#2900)
+    /// Shared scope selection owned by `AppNavigationSplitView`. (#2900)
     @Binding var selectedScopeID: ScopeEntry.ID?
 
     /// Routes to the corresponding content-column view.

--- a/Sources/RunBot/AppShell/AppDestination.swift
+++ b/Sources/RunBot/AppShell/AppDestination.swift
@@ -1,11 +1,11 @@
-// AppSection.swift
+// AppDestination.swift
 // RunBot
 
 import SwiftUI
 
 /// Top-level sidebar route model.
 /// Raw string value prepares for `@SceneStorage` persistence in a later step.
-enum AppSection: String, CaseIterable, Identifiable {
+enum AppDestination: String, CaseIterable, Identifiable {
     /// The workflows feature destination.
     case workflows
     /// The local runners feature destination.

--- a/Sources/RunBot/AppShell/AppDetailColumnView.swift
+++ b/Sources/RunBot/AppShell/AppDetailColumnView.swift
@@ -1,35 +1,35 @@
-// AppDetailView.swift
+// AppDetailColumnView.swift
 // RunBot
 
 import GitHubClient
 import RunBotCore
 import SwiftUI
 
-/// Detail-column router. Shows the step log for the Workflows section and a
-/// neutral placeholder for sections whose content column is self-contained.
+/// Detail-column router. Shows the step log for the Workflows destination and a
+/// neutral placeholder for destinations whose content column is self-contained.
 ///
 /// Selected job and step are derived here from the shared selection plus the
 /// live runner snapshot so the log always reflects current data.
-struct AppDetailView: View {
-    /// The currently selected sidebar section.
-    let selection: AppSection?
+struct AppDetailColumnView: View {
+    /// The currently selected sidebar destination.
+    let selection: AppDestination?
 
     /// Observable runner state pushed by `LocalRunnerStore`.
     let runnerState: RunnerState
-    /// Shared workflow → job → step selection owned by `AppShellView`.
+    /// Shared workflow → job → step selection owned by `AppNavigationSplitView`.
     var workflowSelection: WorkflowSelection
-    /// Selected settings section forwarded from `AppShellView`.
+    /// Selected settings section forwarded from `AppNavigationSplitView`.
     let settingsSelection: SettingsSection?
 
     /// Settings services forwarded from the composition root.
     let settingsDependencies: SettingsDependencies
 
-    /// Shell-owned runner selection forwarded from `AppShellView`. (#2900)
+    /// Shell-owned runner selection forwarded from `AppNavigationSplitView`. (#2900)
     let selectedRunnerID: RunnerModel.ID?
-    /// Shell-owned scope selection forwarded from `AppShellView`. (#2900)
+    /// Shell-owned scope selection forwarded from `AppNavigationSplitView`. (#2900)
     let selectedScopeID: ScopeEntry.ID?
 
-    /// Shared log fetcher — threaded from `AppShellView`.
+    /// Shared log fetcher — threaded from `AppNavigationSplitView`.
     @Binding var logFetcher: LogFetcher
 
     // MARK: - Derived selection

--- a/Sources/RunBot/AppShell/AppNavigationSplitView.swift
+++ b/Sources/RunBot/AppShell/AppNavigationSplitView.swift
@@ -59,7 +59,7 @@ struct AppNavigationSplitView: View {
     let localRunnerStore: LocalRunnerStore
     /// Settings services forwarded from the composition root.
     let settingsDependencies: SettingsDependencies
-    /// Shared log fetcher — owned by `AppDependencies`, threaded down
+    /// Shared log fetcher — owned by `RunBotRuntime`, threaded down
     /// via `@Binding` so the ZIP cache survives column navigations.
     @Binding var logFetcher: LogFetcher
 
@@ -97,7 +97,7 @@ struct AppNavigationSplitView: View {
         .navigationSplitViewStyle(.balanced)
         // Content min-size floor. Must stay in sync with
         // `.windowResizability(.contentMinSize)` + `.defaultSize` in
-        // RunBotDesktopApp — two sources that must never disagree (see the
+        // RunBotApp — two sources that must never disagree (see the
         // one-measurement rule above).
         .frame(minWidth: 720, minHeight: 480)
     }

--- a/Sources/RunBot/AppShell/AppNavigationSplitView.swift
+++ b/Sources/RunBot/AppShell/AppNavigationSplitView.swift
@@ -1,4 +1,4 @@
-// AppShellView.swift
+// AppNavigationSplitView.swift
 // RunBot
 
 import RunBotCore
@@ -33,9 +33,9 @@ import SwiftUI
 ///   the column lives: `navigationSplitViewColumnWidth` here, and per-view
 ///   caps (e.g. the 820 pt readability cap in `SettingsDetailView`) in the
 ///   views that own them.
-struct AppShellView: View {
-    /// Currently selected sidebar section. Defaults to Workflows.
-    @State private var selection: AppSection? = .workflows
+struct AppNavigationSplitView: View {
+    /// Currently selected sidebar destination. Defaults to Workflows.
+    @State private var selection: AppDestination? = .workflows
 
     /// Shared workflow → job → step selection. Owned at the shell level
     /// because the hierarchy and step-log columns both read and mutate it.
@@ -66,14 +66,14 @@ struct AppShellView: View {
     /// The top-level split-view layout.
     var body: some View {
         NavigationSplitView {
-            AppSidebarView(selection: $selection)
+            AppSidebarColumnView(selection: $selection)
                 .navigationSplitViewColumnWidth(
                     min: 180,
                     ideal: 210,
                     max: 260
                 )
         } content: {
-            AppContentView(
+            AppContentColumnView(
                 selection: selection,
                 runnerState: runnerState,
                 localRunnerStore: localRunnerStore,
@@ -83,7 +83,7 @@ struct AppShellView: View {
                 selectedScopeID: $selectedScopeID
             )
         } detail: {
-            AppDetailView(
+            AppDetailColumnView(
                 selection: selection,
                 runnerState: runnerState,
                 workflowSelection: workflowSelection,

--- a/Sources/RunBot/AppShell/AppSidebarColumnView.swift
+++ b/Sources/RunBot/AppShell/AppSidebarColumnView.swift
@@ -1,29 +1,29 @@
-// AppSidebarView.swift
+// AppSidebarColumnView.swift
 // RunBot
 
 import SwiftUI
 
 /// Sidebar column composed of a scrollable navigation list and a pinned metrics footer.
 ///
-/// The navigation `List` and `SidebarMetricsView` are separated by a `Divider`
+/// The navigation `List` and `SidebarMetricsCard` are separated by a `Divider`
 /// inside a `VStack` so metrics stay fixed at the bottom regardless of selection.
 /// Navigation can shrink and scroll independently when the window is short.
-struct AppSidebarView: View {
-    /// Binding to the shell's current section selection.
-    @Binding var selection: AppSection?
+struct AppSidebarColumnView: View {
+    /// Binding to the shell's current destination selection.
+    @Binding var selection: AppDestination?
 
     /// The sidebar layout: scrollable navigation list above a pinned metrics footer.
     var body: some View {
         VStack(spacing: 0) {
-            List(AppSection.allCases, selection: $selection) { section in
-                Label(section.title, systemImage: section.systemImage)
-                    .tag(section)
+            List(AppDestination.allCases, selection: $selection) { destination in
+                Label(destination.title, systemImage: destination.systemImage)
+                    .tag(destination)
             }
             .listStyle(.sidebar)
 
             Divider()
 
-            SidebarMetricsView()
+            SidebarMetricsCard()
                 .padding(.horizontal, 10)
                 .padding(.bottom, 6)
         }

--- a/Sources/RunBot/AppShell/Metrics/SidebarCapacityMetricRow.swift
+++ b/Sources/RunBot/AppShell/Metrics/SidebarCapacityMetricRow.swift
@@ -1,16 +1,16 @@
-// SidebarCapacityMetricView.swift
+// SidebarCapacityMetricRow.swift
 // RunBot
 
 import SwiftUI
 
-// MARK: - SidebarCapacityMetricView
+// MARK: - SidebarCapacityMetricRow
 
 /// Three-zone metric row: header with used/total, capacity progress bar, used/free footer.
 ///
 /// Used for Memory and Disk in the sidebar metrics footer.
 /// Values are expressed in GB (Double) to match `SystemStats` storage.
 /// Adaptive precision: values below 100 GB show one decimal; 100+ show none.
-struct SidebarCapacityMetricView: View {
+struct SidebarCapacityMetricRow: View {
 
     /// Short uppercase label shown as the row heading, e.g. "MEM" or "DISK".
     let title: String

--- a/Sources/RunBot/AppShell/Metrics/SidebarMetricsCard.swift
+++ b/Sources/RunBot/AppShell/Metrics/SidebarMetricsCard.swift
@@ -38,7 +38,7 @@ enum SidebarMetricLayout {
 @MainActor
 struct SidebarMetricsCard: View {
 
-    /// View-local sampler. Constructed once; never written to `AppDependencies`.
+    /// View-local sampler. Constructed once; never written to `RunBotRuntime`.
     @State private var viewModel = SystemStatsViewModel()
 
     /// The four metric rows grouped in a compact material surface.

--- a/Sources/RunBot/AppShell/Metrics/SidebarMetricsCard.swift
+++ b/Sources/RunBot/AppShell/Metrics/SidebarMetricsCard.swift
@@ -1,4 +1,4 @@
-// SidebarMetricsView.swift
+// SidebarMetricsCard.swift
 // RunBot
 
 import RunBotCore
@@ -17,7 +17,7 @@ enum SidebarMetricLayout {
     static let barHeight: CGFloat = 6
 }
 
-// MARK: - SidebarMetricsView
+// MARK: - SidebarMetricsCard
 
 /// Pinned sidebar footer showing live CPU, GPU, memory, and disk metrics.
 ///
@@ -28,7 +28,7 @@ enum SidebarMetricLayout {
 ///
 /// ## Layout
 /// A `thinMaterial` rounded-rectangle groups the four rows inside a compact
-/// footer that stays pinned below the navigation `List` in `AppSidebarView`.
+/// footer that stays pinned below the navigation `List` in `AppSidebarColumnView`.
 /// The footer height is bounded so it cannot consume the entire sidebar when
 /// the window is short.
 ///
@@ -36,7 +36,7 @@ enum SidebarMetricLayout {
 /// Reuses `SystemStatsViewModel`, `SystemStats`, and `SparklineView`.
 /// Does not embed the full-page `SystemStatsView`.
 @MainActor
-struct SidebarMetricsView: View {
+struct SidebarMetricsCard: View {
 
     /// View-local sampler. Constructed once; never written to `AppDependencies`.
     @State private var viewModel = SystemStatsViewModel()
@@ -44,14 +44,14 @@ struct SidebarMetricsView: View {
     /// The four metric rows grouped in a compact material surface.
     var body: some View {
         VStack(spacing: 0) {
-            SidebarUsageMetricView(
+            SidebarUsageMetricRow(
                 title: "CPU",
                 accessibilityTitle: "CPU",
                 value: viewModel.stats.cpuPct,
                 history: viewModel.cpuHistory.values,
                 fractionDigits: 1
             )
-            SidebarUsageMetricView(
+            SidebarUsageMetricRow(
                 title: "GPU",
                 accessibilityTitle: "GPU",
                 value: viewModel.stats.gpuPct,
@@ -59,13 +59,13 @@ struct SidebarMetricsView: View {
                 fractionDigits: 0
             )
 
-            SidebarCapacityMetricView(
+            SidebarCapacityMetricRow(
                 title: "MEM",
                 accessibilityTitle: "Memory",
                 used: viewModel.stats.memUsedGB,
                 total: viewModel.stats.memTotalGB
             )
-            SidebarCapacityMetricView(
+            SidebarCapacityMetricRow(
                 title: "DISK",
                 accessibilityTitle: "Disk",
                 used: viewModel.stats.diskUsedGB,

--- a/Sources/RunBot/AppShell/Metrics/SidebarUsageMetricRow.swift
+++ b/Sources/RunBot/AppShell/Metrics/SidebarUsageMetricRow.swift
@@ -1,16 +1,16 @@
-// SidebarUsageMetricView.swift
+// SidebarUsageMetricRow.swift
 // RunBot
 
 import SwiftUI
 
-// MARK: - SidebarUsageMetricView
+// MARK: - SidebarUsageMetricRow
 
 /// Two-zone metric row: percentage header and full-width severity-colored sparkline.
 ///
 /// Used for CPU and GPU in the sidebar metrics footer.
 /// When `value` is `nil` the header shows an em-dash and a neutral
 /// empty graph band is rendered without fabricating zero samples.
-struct SidebarUsageMetricView: View {
+struct SidebarUsageMetricRow: View {
 
     /// Short uppercase label shown as the row heading, e.g. "CPU".
     let title: String

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -150,8 +150,8 @@ extension Color {
     /// - >60–85 % → orange (`.rbWarning`)
     /// - >85 %    → red (`.rbDanger`)
     ///
-    /// Used by `SparklineView`, `SidebarUsageMetricView`, and
-    /// `SidebarCapacityMetricView` so threshold logic is defined once.
+    /// Used by `SparklineView`, `SidebarUsageMetricRow`, and
+    /// `SidebarCapacityMetricRow` so threshold logic is defined once.
     static func rbMetricSeverity(percentage: Double) -> Color {
         let clamped = min(max(percentage, 0), 100)
         if clamped > 85 { return .rbDanger }

--- a/Sources/RunBot/Features/LocalRunners/RunnerDetailView.swift
+++ b/Sources/RunBot/Features/LocalRunners/RunnerDetailView.swift
@@ -58,7 +58,7 @@ struct RunnerDetailView: View {
             .padding(.bottom, 28)
             // Same load-bearing 820 pt readability cap as SettingsDetailView —
             // keep the two in sync. Do not replace with idealWidth: it is a
-            // preference, not a constraint (see AppShellView sizing contract).
+            // preference, not a constraint (see AppNavigationSplitView sizing contract).
             .frame(maxWidth: 820, alignment: .topLeading)
         }
         .task(id: runner.id) { await loadDisplayFields(for: runner) }

--- a/Sources/RunBot/Features/LocalRunners/RunnerListDestination.swift
+++ b/Sources/RunBot/Features/LocalRunners/RunnerListDestination.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 /// Owns sheet presentation and action dispatch while keeping
 /// `RunnerListView` purely presentational. Selection is
-/// owned by `AppShellView` and passed in as a binding so the detail
+/// owned by `AppNavigationSplitView` and passed in as a binding so the detail
 /// column can resolve the selected runner independently. (#2900)
 @MainActor
 struct RunnerListDestination: View {
@@ -22,7 +22,7 @@ struct RunnerListDestination: View {
     let runnerState: RunnerState
     /// The configured local-runner store.
     let localRunnerStore: LocalRunnerStore
-    /// Shell-owned selection binding shared with `AppDetailView`.
+    /// Shell-owned selection binding shared with `AppDetailColumnView`.
     @Binding var selectedRunnerID: RunnerModel.ID?
 
     // MARK: - Environment

--- a/Sources/RunBot/Features/Scopes/ScopeDetailDestination.swift
+++ b/Sources/RunBot/Features/Scopes/ScopeDetailDestination.swift
@@ -16,7 +16,7 @@ struct ScopeDetailDestination: View {
 
     /// Live scope store injected at the composition boundary.
     let scopeStore: ScopeStore
-    /// Shell-owned selection ID forwarded from `AppDetailView`.
+    /// Shell-owned selection ID forwarded from `AppDetailColumnView`.
     let selectedScopeID: ScopeEntry.ID?
 
     // MARK: - Body

--- a/Sources/RunBot/Features/Scopes/ScopeListDestination.swift
+++ b/Sources/RunBot/Features/Scopes/ScopeListDestination.swift
@@ -10,7 +10,7 @@ import SwiftUI
 ///
 /// Owns sheet presentation and action dispatch while keeping
 /// `ScopeListView` purely presentational. Selection is
-/// owned by `AppShellView` and passed in as a binding so the detail
+/// owned by `AppNavigationSplitView` and passed in as a binding so the detail
 /// column can resolve the selected scope independently. (#2900)
 @MainActor
 struct ScopeListDestination: View {
@@ -19,7 +19,7 @@ struct ScopeListDestination: View {
 
     /// The shared scope store, injected at the composition boundary.
     let scopeStore: ScopeStore
-    /// Shell-owned selection binding shared with `AppDetailView`.
+    /// Shell-owned selection binding shared with `AppDetailColumnView`.
     @Binding var selectedScopeID: ScopeEntry.ID?
 
     // MARK: - Local UI state

--- a/Sources/RunBot/Features/Settings/SettingsDependencies.swift
+++ b/Sources/RunBot/Features/Settings/SettingsDependencies.swift
@@ -9,7 +9,7 @@ import RunBotCore
 /// Holds the services genuinely needed by the windowed Settings destination.
 ///
 /// Owned once by `AppDependencies` and threaded through
-/// `AppShellView` → `AppDetailView` → `SettingsListView`.
+/// `AppNavigationSplitView` → `AppDetailColumnView` → `SettingsListView`.
 /// Do not instantiate services inside this type — receive them from
 /// the composition root to avoid the startup-coupling regression
 /// removed after issue #2815.

--- a/Sources/RunBot/Features/Settings/SettingsDependencies.swift
+++ b/Sources/RunBot/Features/Settings/SettingsDependencies.swift
@@ -8,7 +8,7 @@ import RunBotCore
 
 /// Holds the services genuinely needed by the windowed Settings destination.
 ///
-/// Owned once by `AppDependencies` and threaded through
+/// Owned once by `RunBotRuntime` and threaded through
 /// `AppNavigationSplitView` → `AppDetailColumnView` → `SettingsListView`.
 /// Do not instantiate services inside this type — receive them from
 /// the composition root to avoid the startup-coupling regression

--- a/Sources/RunBot/Features/Settings/SettingsDetailView.swift
+++ b/Sources/RunBot/Features/Settings/SettingsDetailView.swift
@@ -43,7 +43,7 @@ import SwiftUI
 ///   preference, not a constraint, and is ignored when the parent offers more.
 /// - ❌ Do not wrap this view's root `ScrollView` in a GeometryReader to
 ///   measure it — measurement has exactly one owner (see the SIZING CONTRACT
-///   on `AppShellView`). Measuring here reintroduces the multi-source
+///   on `AppNavigationSplitView`). Measuring here reintroduces the multi-source
 ///   disagreement that caused #2278/#2279 and the side-jump family (#375–377).
 /// - `.fixedSize(horizontal: false, vertical: true)` on multi-line rows in
 ///   the section views (Updates, General, Authentication cards) is

--- a/Sources/RunBot/Features/Settings/SettingsDetailView.swift
+++ b/Sources/RunBot/Features/Settings/SettingsDetailView.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///
 /// ## Dependency rules
 /// - `GitHubAuthentication` is read from the environment (owned by
-///   `RunBotDesktopApp`). No second instance is created here.
+///   `RunBotApp`). No second instance is created here.
 /// - `onToggleEnvironment` selects `.environment`, `.oauth` (when signed in),
 ///   or `.unauthenticated` to match main's toggle logic.
 /// - A `.task` on `AuthenticationSection` runs `refreshAuthentication()` once

--- a/Sources/RunBot/Features/Settings/SettingsListView.swift
+++ b/Sources/RunBot/Features/Settings/SettingsListView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Settings section list shown in the content column of the app shell.
 ///
 /// Shows a compact "Settings" title above the section list, then the
-/// section rows. Selection is owned by `AppShellView` and flows down
+/// section rows. Selection is owned by `AppNavigationSplitView` and flows down
 /// as a binding. (#2898)
 ///
 /// ## Row styling

--- a/Sources/RunBot/Features/Settings/SettingsSection.swift
+++ b/Sources/RunBot/Features/Settings/SettingsSection.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Identifies each row in the settings list pane.
 ///
-/// Mirrors the shape of `AppSection`: `String`-backed, `CaseIterable`,
+/// Mirrors the shape of `AppDestination`: `String`-backed, `CaseIterable`,
 /// `Identifiable` with `id: Self`, so it can drive a `List(selection:)`
 /// binding directly.
 enum SettingsSection: String, CaseIterable, Identifiable {

--- a/Sources/RunBot/Features/Workflows/WorkflowHierarchyView.swift
+++ b/Sources/RunBot/Features/Workflows/WorkflowHierarchyView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 struct WorkflowHierarchyView: View {
     /// Observable runner state. Observed directly to stay live across polls.
     @Bindable var runnerState: RunnerState
-    /// Shared selection state owned by `AppShellView`.
+    /// Shared selection state owned by `AppNavigationSplitView`.
     var selection: WorkflowSelection
 
     /// IDs of workflows whose job lists are currently expanded.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+InstallPathMap.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+InstallPathMap.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Lookup maps built from the local runner list, used by `fetchAndEnrichRunners`.
 ///
 /// `public` so the app target can reference the type (e.g. in tests and in
-/// `AppDependencies` for DI wiring). `buildInstallPathMap` is `internal`
+/// `RunBotRuntime` for DI wiring). `buildInstallPathMap` is `internal`
 /// — it is only called from within `RunBotCore`.
 public struct InstallPathMap {
     /// Maps "scope/runnerName" to installPath (exact scope-prefixed match).

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -5,7 +5,7 @@
 
 /// Minimal interface for the GitHub poll-loop actor.
 ///
-/// Typed as `any RunnerPollerProtocol` in `AppDependencies` so tests and
+/// Typed as `any RunnerPollerProtocol` in `RunBotRuntime` so tests and
 /// SwiftUI previews can substitute a `MockPoller` without importing the RunBot app target.
 public protocol RunnerPollerProtocol: AnyObject {
     /// Starts the poll loop, observers, and initial fetch.

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerStore.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerStore.swift
@@ -30,7 +30,7 @@ public actor LocalRunnerStore {
     /// The app-wide shared instance. Must be called on the main actor.
     ///
     /// ⚠️ Must not be accessed before `configure(viewModel:)` is called from
-    /// `AppDependencies.init`. Accessing it earlier
+    /// `RunBotRuntime.init`. Accessing it earlier
     /// produces a `fatalError` with a diagnostic message.
     @MainActor
     public static var shared: LocalRunnerStore {
@@ -82,7 +82,7 @@ public actor LocalRunnerStore {
     /// The current list of locally-installed runners, sorted by name.
     /// Private: all external reads go through `viewModel.localRunners` (pushed via MainActor.run).
     /// Widening to internal is unnecessary — the `localRunners` closure in
-    /// `AppDependencies` reads `runnerState.localRunners`, not this
+    /// `RunBotRuntime` reads `runnerState.localRunners`, not this
     /// property directly.
     private var runners: [RunnerModel] = []
 
@@ -272,7 +272,7 @@ public actor LocalRunnerStore {
     /// Awaitable refresh. Suspends until disk hydration + launchctl + GitHub enrichment
     /// completes, then returns.
     ///
-    /// Use ONLY at app startup in `AppDependencies.start()` so that the
+    /// Use ONLY at app startup in `RunBotRuntime.start()` so that the
     /// poll loop is guaranteed to have a populated `runners` array before its
     /// first `fetch()` fires.
     public func refreshAsync() async {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,11 +52,11 @@ main.swift
     │   │   └── PollLoopCoordinator
     │   └── SettingsDependencies
     │       └── AppUpdater
-    └── AppShellView
+    └── AppNavigationSplitView
         └── NavigationSplitView
-            ├── AppSidebarView
-            ├── AppContentView
-            └── AppDetailView
+            ├── AppSidebarColumnView
+            ├── AppContentColumnView
+            └── AppDetailColumnView
 ```
 
 - `main.swift` calls `RunBotDesktopApp.main()` inside `MainActor.assumeIsolated`.
@@ -90,7 +90,7 @@ RunBotDesktopApp.init
 → configure LocalRunnerStore synchronously
 → construct GitHubClient and RunnerPoller
 → construct OAuthCredentialController
-→ mount AppShellView
+→ mount AppNavigationSplitView
 → AppDependencies.start()
 → reconcile OAuth state
 → start OAuth observation
@@ -120,18 +120,18 @@ A three-column `NavigationSplitView` shell:
 
 | Column | Router | Responsibilities |
 |---|---|---|
-| Sidebar | `AppSidebarView` | Top-level section selection and pinned system metrics |
-| Content | `AppContentView` | Workflow hierarchy, local runners, scopes, or settings list |
-| Detail | `AppDetailView` | Step log, runner detail, scope detail, or settings detail |
+| Sidebar | `AppSidebarColumnView` | Top-level destination selection and pinned system metrics |
+| Content | `AppContentColumnView` | Workflow hierarchy, local runners, scopes, or settings list |
+| Detail | `AppDetailColumnView` | Step log, runner detail, scope detail, or settings detail |
 
 State ownership:
 
-- `AppShellView` owns top-level section selection.
+- `AppNavigationSplitView` owns top-level destination selection.
 - `WorkflowSelection` owns workflow → job → step selection.
 - Runner, scope, and settings selection are owned by the shell and passed down
   as bindings so the content list and detail column stay consistent (#2900).
 - `LogFetcher` is app-owned (`RunBotDesktopApp` creates the single `@State`
-  instance and threads it into `AppShellView` via `@Binding`) so its ZIP cache
+  instance and threads it into `AppNavigationSplitView` via `@Binding`) so its ZIP cache
   survives navigation and view remounts.
 - Detail views resolve selected models from current observable snapshots rather
   than retaining stale copies.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,10 +40,10 @@ Regression guards and architectural decisions are enforced inline in the source.
 
 ```
 main.swift
-└── RunBotDesktopApp
+└── RunBotApp
     ├── GitHubAuthentication
     ├── LogFetcher
-    ├── AppDependencies
+    ├── RunBotRuntime
     │   ├── GitHubClient
     │   ├── OAuthCredentialController
     │   ├── RunnerState
@@ -59,14 +59,14 @@ main.swift
             └── AppDetailColumnView
 ```
 
-- `main.swift` calls `RunBotDesktopApp.main()` inside `MainActor.assumeIsolated`.
+- `main.swift` calls `RunBotApp.main()` inside `MainActor.assumeIsolated`.
   (`@main` cannot coexist with top-level code in `main.swift`; never remove the
   `assumeIsolated` wrapper — the OS always starts on the main thread and this
   satisfies strict-concurrency checking.)
-- `RunBotDesktopApp` is the application composition root. It constructs
+- `RunBotApp` is the application composition root. It constructs
   authentication and dependencies synchronously before any view is mounted and
   handles the OAuth callback via `.onOpenURL`.
-- `AppDependencies` owns all long-lived domain services for the app
+- `RunBotRuntime` owns all long-lived domain services for the app
   lifetime. Views receive shared state and services; they never construct their
   own instances of stores, clients, or pollers.
 - `RunnerState` is the observable read model for the UI. Poll-owned
@@ -81,17 +81,17 @@ main.swift
 
 ## Startup lifecycle
 
-The order below is encoded by `AppDependencies`:
+The order below is encoded by `RunBotRuntime`:
 
 ```
-RunBotDesktopApp.init
+RunBotApp.init
 → create GitHubAuthentication
-→ create AppDependencies
+→ create RunBotRuntime
 → configure LocalRunnerStore synchronously
 → construct GitHubClient and RunnerPoller
 → construct OAuthCredentialController
 → mount AppNavigationSplitView
-→ AppDependencies.start()
+→ RunBotRuntime.start()
 → reconcile OAuth state
 → start OAuth observation
 → refresh local runners
@@ -130,7 +130,7 @@ State ownership:
 - `WorkflowSelection` owns workflow → job → step selection.
 - Runner, scope, and settings selection are owned by the shell and passed down
   as bindings so the content list and detail column stay consistent (#2900).
-- `LogFetcher` is app-owned (`RunBotDesktopApp` creates the single `@State`
+- `LogFetcher` is app-owned (`RunBotApp` creates the single `@State`
   instance and threads it into `AppNavigationSplitView` via `@Binding`) so its ZIP cache
   survives navigation and view remounts.
 - Detail views resolve selected models from current observable snapshots rather
@@ -192,7 +192,7 @@ Keychain.
 
 **How RunBot wires it up:**
 
-`AppDependencies` constructs a single `GitHubClient` instance in
+`RunBotRuntime` constructs a single `GitHubClient` instance in
 `init()`, passing Keychain credentials (service/account names must match the
 pre-GitHubClient keychain entries — changing them orphans stored tokens) and an
 auth-source closure reading `GitHubAuthentication`. The client's `oauthService`
@@ -206,7 +206,7 @@ and transport references are injected into `RunBotCore` types (`RunnerPoller`,
 - `fetchJobs(runID:scope:)` — called when a run is expanded in the UI to load its jobs and steps
 - `fetchStepLog(jobID:stepNumber:scope:)` — called by `LogFetcher` to retrieve and display per-step CI logs
 - `fetchUserOrgs()` / `fetchUserRepos()` — called by `AddScopeSheet` to populate the scope picker
-- `oauthService.makeSignInURL()` / `oauthService.handleCallback(_:)` — sign-in URL opened from the settings auth card; callbacks arrive via `.onOpenURL` → `AppDependencies.handleOAuthCallback(_:)`
+- `oauthService.makeSignInURL()` / `oauthService.handleCallback(_:)` — sign-in URL opened from the settings auth card; callbacks arrive via `.onOpenURL` → `RunBotRuntime.handleOAuthCallback(_:)`
 
 **Token resolution in RunBot's context:**
 
@@ -218,7 +218,7 @@ Credentials never fall back across modes. Discovering an environment token only 
 
 All tests that touch network or Keychain inject mock transports and OAuth services via the `GitHubClient(oauthService:transport:)` test initialiser. No production `GitHubClient` instance is created in the test suite.
 
-- ❌ NEVER construct a second `GitHubClient` instance — the one created by `AppDependencies` is the single source of truth for tokens and rate-limit state.
+- ❌ NEVER construct a second `GitHubClient` instance — the one created by `RunBotRuntime` is the single source of truth for tokens and rate-limit state.
 
 ---
 
@@ -242,10 +242,10 @@ The package tracks the `main` branch. Dependency pinning and release behavior ar
 
 **How RunBot wires it up:**
 
-`AppDependencies.init()` constructs a single `AppUpdater` instance inside `SettingsDependencies`, initialised with RunBot's GitHub repo slug, the current bundle version, the expected zip asset name, an Ed25519 public key (embedded in the binary as a base64 constant), and the `NSBackgroundActivityScheduler` identifier. Its `UpdateState`-conforming state object drives update UI via observation.
+`RunBotRuntime.init()` constructs a single `AppUpdater` instance inside `SettingsDependencies`, initialised with RunBot's GitHub repo slug, the current bundle version, the expected zip asset name, an Ed25519 public key (embedded in the binary as a base64 constant), and the `NSBackgroundActivityScheduler` identifier. Its `UpdateState`-conforming state object drives update UI via observation.
 
 ```swift
-// AppDependencies.swift (illustrative)
+// RunBotRuntime.swift (illustrative)
 let updater = AppUpdater(
     repo: "runbot-hq/run-bot",
     currentVersion: Bundle.main.rbVersionString,
@@ -267,7 +267,7 @@ let updater = AppUpdater(
 
 **Ed25519 key:**
 
-The public key is embedded as a base64 constant in `AppDependencies.swift` (not in `UserDefaults` or any plist). The matching private key lives as a GitHub Actions secret and is used by the release workflow to sign each `RunBot.zip` artifact before upload.
+The public key is embedded as a base64 constant in `RunBotRuntime.swift` (not in `UserDefaults` or any plist). The matching private key lives as a GitHub Actions secret and is used by the release workflow to sign each `RunBot.zip` artifact before upload.
 
 **`fixedZipURL` invariant:**
 
@@ -362,7 +362,7 @@ sign-off (a deliberate Principle #4 exception) so `deinit` can cancel the handle
 
 ### `RunnerPollerProtocol` and `MockPoller`
 
-`AppDependencies` types the poller as `any RunnerPollerProtocol`
+`RunBotRuntime` types the poller as `any RunnerPollerProtocol`
 (`func start() async` + `var state: RunnerState { get }`). `RunnerPoller` is the
 production conformer; `MockPoller` is a no-op actor for SwiftUI previews and
 snapshot tests — `start()` is a guaranteed no-op that never touches the network.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -160,7 +160,7 @@ cd ~/run-bot && \
 pkill -x RunBot 2>/dev/null || true && \
 sleep 1 && \
 rm -rf dist/ && \
-touch Sources/RunBot/App/RunBotDesktopApp.swift && \
+touch Sources/RunBot/App/RunBotApp.swift && \
 bash build.sh && \
 sleep 1 && \
 log stream --level debug \
@@ -657,7 +657,7 @@ RunBot checks for updates in the background and presents a single update row in 
 Release archives are authenticated with an Ed25519 signature. The publish workflow signs
 `RunBot.zip` and produces `RunBot.zip.sig` (a raw 64-byte Ed25519 signature).
 `AppUpdater` downloads this sidecar and verifies it against the Ed25519 public key embedded
-in `AppDependencies` before installation. A signature mismatch sets `updateActionFailed = true`.
+in `RunBotRuntime` before installation. A signature mismatch sets `updateActionFailed = true`.
 
 This is separate from macOS code signing:
 
@@ -669,7 +669,7 @@ This is separate from macOS code signing:
 
 | Type | Role |
 |---|---|
-| `AppUpdater` | Owns update checks, scheduling, download, Ed25519 verification, installation, and relaunch — lives in `runbot-hq/AppUpdater`; instantiated in `AppDependencies` |
+| `AppUpdater` | Owns update checks, scheduling, download, Ed25519 verification, installation, and relaunch — lives in `runbot-hq/AppUpdater`; instantiated in `RunBotRuntime` |
 | `RunnerState` | `@Observable @MainActor`; implements the update-state contract consumed by `AppUpdater` and the Settings UI |
 | `SettingsDependencies` | Carries the shared `AppUpdater` instance from the composition root into Settings |
 


### PR DESCRIPTION
Closes #3017.

Mechanical naming pass over `Sources/RunBot/AppShell/`. The files were already
well separated structurally, but `AppContentView`/`AppDetailView` were too
generic, `AppSection` is really a destination model, and the metrics filenames
described implementation categories rather than their card/row roles.

## Renames

| Current | New | Reason |
|---|---|---|
| `AppShellView` | `AppNavigationSplitView` | Owns the top-level `NavigationSplitView`, shared selections, three-column wiring |
| `AppSidebarView` | `AppSidebarColumnView` | Renders the sidebar column |
| `AppContentView` | `AppContentColumnView` | Routes the middle/content column |
| `AppDetailView` | `AppDetailColumnView` | Routes the detail column |
| `AppSection` | `AppDestination` | Cases are selectable top-level destinations |
| `SidebarMetricsView` | `SidebarMetricsCard` | Groups the four rows in one material/card surface |
| `SidebarUsageMetricView` | `SidebarUsageMetricRow` | One reusable CPU/GPU row |
| `SidebarCapacityMetricView` | `SidebarCapacityMetricRow` | One reusable memory/disk row |

Resulting folder:

```text
AppShell/
├── AppNavigationSplitView.swift
├── AppSidebarColumnView.swift
├── AppContentColumnView.swift
├── AppDetailColumnView.swift
├── AppDestination.swift
└── Metrics/
    ├── SidebarMetricsCard.swift
    ├── SidebarUsageMetricRow.swift
    └── SidebarCapacityMetricRow.swift
```

The three column names now mirror SwiftUI's `NavigationSplitView` terminology, so
ownership is visible without opening each file. The `App` prefix is retained on the
five navigation-shell symbols — they are app-level routing infrastructure and would
otherwise collide with feature-local content/detail types.

## Scope

Pure rename — no behaviour, layout, or API-shape changes.

- All 8 files moved with `git mv` (rename detection preserved).
- Call sites updated: `RunBotDesktopApp`, `DesignTokens`, and the Settings /
  LocalRunners / Scopes / Workflows feature files that referenced the shell in doc
  comments.
- File headers (`// <Filename>.swift`) and `// MARK:` names updated to match.
- `docs/architecture.md` updated.
- Doc-comment prose that called `AppSection` a "sidebar section" now says
  "destination"; the sidebar `List` closure variable is `destination`.
  `SettingsSection` wording is deliberately untouched.

## Verification

- `swift build` — Build complete (only pre-existing unrelated warnings)
- `swift test` — 118 tests in 27 suites passed
- `swiftlint lint --strict` — 0 violations in 173 files

Targets `fix-migrate-to-app-shell-step-34` (PR #3006) as the next link in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename application shell, runtime, and metrics components to make ownership and routing responsibilities explicit without changing behavior.

Enhancements:
- Rename the application composition root and runtime types to better reflect their roles.
- Align AppShell navigation and metrics symbols with their NavigationSplitView column, destination, card, and row responsibilities.

Documentation:
- Update architecture and deployment documentation to use the renamed application and navigation components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the app's composition and shell types to match their roles. `RunBotDesktopApp` becomes `RunBotApp` (the "Desktop" qualifier predates the retired menu-bar app), and `AppDependencies` becomes `RunBotRuntime` since it owns the process-lifetime domain state.

**Refactors**
- `AppShellView` → `AppNavigationSplitView`, with sidebar/content/detail views renamed to their `NavigationSplitView` column roles.
- `AppSection` → `AppDestination`; metrics views become `SidebarMetricsCard` and `SidebarUsageMetricRow`/`SidebarCapacityMetricRow`.
- `RunBotDesktopApp` → `RunBotApp` and `AppDependencies` → `RunBotRuntime`, with the `deps` property renamed `runtime`.
- Pure renames: no behavior, layout, or API changes. Call sites, doc comments, file headers, and `docs/architecture.md` and `docs/deployment.md` are updated.

<sup>Written for commit 9c1f58c68572df23c6a31b1434555d9e4b8285eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/3019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

