### PR TITLE
docs: fix stale code comments left by the AppShell migration (#3029)

### DIFF
--- a/.github/workflows/comment-symbols.yml
+++ b/.github/workflows/comment-symbols.yml
@@ -1,0 +1,20 @@
+name: Comment Symbol Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  comment-symbols:
+    name: Comment symbols
+    runs-on: macos-26
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        # Branch-pinned by convention — see the note in periphery.yml.
+        uses: actions/checkout@v4
+
+      - name: Check comments for references to deleted symbols
+        run: python3 scripts/check-comment-symbols.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ swift build                                   # type-check the whole package
 swift test                                    # run all test suites (RunBotCoreTests + AppUpdaterTests)
 swiftlint lint --strict                       # CI fails on warnings, not just errors
 periphery scan                                # dead-code scan (config: .periphery.yml)
+python3 scripts/check-comment-symbols.py      # fail if a comment names a symbol that no longer exists
 swift run                                      # build + launch the app locally
 bash build.sh                                  # release build via xcodegen+xcodebuild (arm64 only; requires xcodegen)
 ```
@@ -54,7 +55,7 @@ Don't reformat unrelated code to satisfy the linter — keep diffs scoped to you
 
 ## Project layout
 
-Two targets plus a test target (full map: `docs/architecture/file-hierarchy.md`):
+Two targets plus a test target (full map: `docs/architecture.md`):
 
 ```
 Sources/RunBotCore/   library — pure logic, no UI; the testable core
@@ -108,26 +109,31 @@ ones**. That's why `AppDelegate`, `AddRunnerSheet`, and `RunnerPoller` are split
 - **Immutable, `Sendable` value models** (`Runner`, `RunnerModel`, config types): `let` properties,
   mutate via `copying(…)`. No `@unchecked Sendable` in production types except the documented
   sign-off on `PollLoopCoordinator`.
-- See `docs/architecture/ARCHITECTURE.md` for the data model, concurrency model, and library rationale detail, and `docs/principles/project-tech-principles.md` for the canonical 21 principles this codebase commits to.
+- See `docs/architecture.md` for the data model, concurrency model, and library rationale detail, and `docs/principles.md` for the canonical principles this codebase commits to.
 
 ## GitHub networking & auth
 
 - **Do not shell out to `gh api`.** Networking goes through a `URLSession`-based transport
   (`GitHubTransportProtocol` / `GitHubURLSessionTransport`), with typed `Codable` decoding, the
-  `GitHubRateLimitHandler` actor, and Link-header pagination (`ghAPIPaginated`).
-- In tests, inject a stub conforming to `GitHubTransportProtocol` (see `GitHubTransportShimTests`
-  and `StubURLProtocol`). Never hit the live network in tests.
-- **Auth** is resolved by `GitHubTokenCache` / `OAuthService`, priority order: in-app OAuth
+  `GitHubRateLimitHandler` actor, and Link-header pagination (`apiPaginated`). These live in
+  the in-repo `Packages/GitHubClient` package, not in `RunBotCore`.
+- In tests, inject a stub conforming to `GitHubTransportProtocol` (see `StubURLProtocol` and the
+  per-suite stub transports, e.g. `FetchStepStubTransport`). Never hit the live network in tests.
+- **Auth** is resolved by `TokenCache` / `OAuthService`, priority order: in-app OAuth
   sign-in (Keychain) → `GH_TOKEN` → `GITHUB_TOKEN`. `gh auth login` / `gh auth token` is **not**
   a supported path (removed in Batch 18) — don't reference it in code, strings, or docs.
 
 ## UI notes
 
-- Menu-bar-only (no Dock icon). Dot colour reflects `AggregateStatus`.
-- **Popover side-jump is a known hazard.** Before touching panel sizing/anchoring, read
-  `docs/ui/popover-side-jump-prevention.md` and `docs/ui/nspopover-dynamic-width.md`, and respect
-  the regression guards in `PanelMainView` / `PanelVisibilityState` (refs #375–377).
-  Sheets/dismiss: `docs/ui/nspopover-dismiss-and-sheets.md`.
+- Windowed app: a single SwiftUI `Window` scene hosting `AppNavigationSplitView`
+  (sidebar / content / detail). The menu-bar popover and its owned panel are both gone.
+  Dot colour reflects `AggregateStatus`.
+- **Sizing is a known hazard.** The popover-era side-jump and stale-cap regressions
+  (#375–377, #2278/#2279, #2305) were all caused by more than one layer measuring content.
+  The rule survived the migration: ONE MEASUREMENT, ONE OWNER. Read the SIZING CONTRACT
+  comments on `AppNavigationSplitView`, `SettingsDetailView`, and `StepLogContentView`
+  before changing any frame, and do not size a window from `.preferredContentSize`,
+  a GeometryReader feedback loop, or an invisible measuring pass.
 - Follow the macOS 26 Liquid Glass design system (`ColorTokens`, `SurfaceModifiers`); support
   dark & light mode.
 

--- a/Package.swift
+++ b/Package.swift
@@ -42,12 +42,15 @@ let package = Package(
         ),
         .executableTarget(
             name: "RunBot",
-            // GitHubClient is declared explicitly because AppDelegate+StoreSetup.swift
-            // calls configureGHAPI / configureGHRaw / configureGHAPIPaginated /
-            // configureGHLogger directly. SwiftPM does not re-export transitive
-            // dependencies, so the symbols are only visible when GitHubClient is a
-            // direct dependency of this target. AppUpdater is consumed transitively
-            // via RunBotCore and needs no explicit entry.
+            // GitHubClient is declared explicitly because the app target uses its
+            // types directly, not only through RunBotCore: RunBotRuntime constructs
+            // GitHubClient and OAuthCredentialController, RunBotApp reads
+            // GitHubConstants for the OAuth callback, and roughly twenty UI files
+            // import GitHubClient for GitHubAuthentication / GitHubStep / OAuthState.
+            // SwiftPM does not re-export transitive dependencies, so those symbols
+            // are only visible when GitHubClient is a direct dependency of this
+            // target. AppUpdater is consumed transitively via RunBotCore and needs
+            // no explicit entry.
             dependencies: [
                 "RunBotCore",
                 .product(name: "GitHubClient", package: "GitHubClient"),

--- a/Sources/RunBot/App/RunBotApp.swift
+++ b/Sources/RunBot/App/RunBotApp.swift
@@ -5,7 +5,7 @@ import GitHubClient
 import RunBotCore
 import SwiftUI
 
-// @main removed: Sources/RunBot/main.swift is top-level code.
+// @main removed: Sources/RunBot/App/main.swift is top-level code.
 // RunBotApp.main() is called from main.swift instead.
 
 /// The SwiftUI application entry point for RunBot.

--- a/Sources/RunBot/App/RunBotRuntime.swift
+++ b/Sources/RunBot/App/RunBotRuntime.swift
@@ -11,9 +11,18 @@ import RunBotCore
 
 /// Owns and configures the long-lived domain services required by the windowed app.
 ///
-/// `LocalRunnerStore.configure(viewModel:)` must be the very first call,
-/// synchronously, before any view is mounted. This mirrors the ordering rule
-/// documented in `AppDelegate+StoreSetup.swift` (fix for issue #1741).
+/// ## Startup ordering rule (#1741) — load-bearing
+/// `LocalRunnerStore.configure(viewModel:)` must be the very first call, made
+/// **synchronously in `init()`**, before any view is mounted. `LocalRunnerStore`
+/// is a shared singleton that pushes snapshots into its configured view model;
+/// if any view mounts and reads `LocalRunnerStore.shared` before `configure`
+/// runs, the store publishes into a view model nobody is observing and the
+/// runner list stays empty until the next refresh. Do not move this call into
+/// `start()`, a `Task`, or any `async` context — the fix for #1741 was precisely
+/// to pull it back out of one.
+///
+/// (This rule was previously documented in `AppDelegate+StoreSetup.swift`, which
+/// the AppShell migration deleted. This type is now its only home.)
 ///
 /// Startup ordering:
 ///   LocalRunnerStore.configure    <- synchronous, in init()
@@ -37,7 +46,12 @@ final class RunBotRuntime {
     private let github: GitHubClient
     /// Manages OAuth credential storage, refresh, and sign-out.
     private let oauthCredentials: OAuthCredentialController
-    /// The live runner poller; `nil` until `start()` has been called once.
+    /// The live runner poller.
+    ///
+    /// Assigned unconditionally in `init()`, so it is never `nil` in practice —
+    /// the optionality is a leftover from the pre-AppShell lifecycle where the
+    /// poller was seeded after launch. The `guard let` in `start()` is therefore
+    /// defensive only; do not read it as evidence of a real nil state.
     private var runnerStore: (any RunnerPollerProtocol)?
     /// Guards against duplicate `start()` calls (SwiftUI `.task` can fire more than once).
     private var didStart = false
@@ -45,8 +59,15 @@ final class RunBotRuntime {
     /// Creates the domain runtime for the windowed app shell.
     /// - Parameters:
     ///   - authentication: GitHub authentication controller.
-    ///   - onSignIn: Closure called on the main actor after a successful sign-in.
-    ///   - onSignOut: Async closure called on the main actor after sign-out completes.
+    ///   - onSignIn: **Currently unread.** Intended as a post-sign-in hook, but the
+    ///     sign-in action handed to `SettingsDependencies` is built from
+    ///     `oauthCredentials` below, not from this parameter. The sole call site
+    ///     (`RunBotApp.init`) passes an empty closure, so nothing is lost today —
+    ///     but do not assume passing a non-empty closure here has any effect.
+    ///     Wire it or drop it; see #3029.
+    ///   - onSignOut: **Currently unread**, for the same reason. Sign-out is routed
+    ///     through `credentials.didSignOut` and the `SettingsDependencies.onSignOut`
+    ///     closure, both constructed here.
     init(
         authentication: GitHubAuthentication,
         onSignIn: @escaping @MainActor () -> Void,
@@ -60,7 +81,6 @@ final class RunBotRuntime {
         LocalRunnerStore.configure(viewModel: state)
         self.localRunnerStore = LocalRunnerStore.shared
 
-        // GitHub client - same configuration as AppState.
         // WARNING: service/account match the pre-GitHubClient keychain entry name.
         // Do NOT change - doing so orphans stored tokens and forces re-authentication.
         let client = GitHubClient(
@@ -73,7 +93,8 @@ final class RunBotRuntime {
         )
         self.github = client
 
-        // Poll-loop actor - mirrors AppState.seedStoreAndPoller().
+        // Poll-loop actor. Constructed here rather than in `start()` so that
+        // `credentials.didSignOut` below can capture it weakly.
         let poller = RunnerPoller(
             state: state,
             preferencesStore: AppPreferencesStore.shared,
@@ -90,7 +111,6 @@ final class RunBotRuntime {
         )
         self.runnerStore = poller
 
-        // Credential controller - same init as AppState.
         // didSignOut restarts the poll loop after sign-out.
         let credentials = OAuthCredentialController(
             service: client.oauthService,
@@ -158,7 +178,7 @@ extension RunBotRuntime {
     ///
     /// Idempotent - SwiftUI may recreate the root .task; subsequent calls are no-ops.
     ///
-    /// Ordering mirrors the domain subset of AppState.start():
+    /// Ordering (all three steps are required, in this order):
     ///   1. reconcile + start observations - sync, before first await
     ///   2. localRunnerStore.refreshAsync  - hydrates local runners
     ///   3. runnerStore.start              - begins GitHub poll loop

--- a/Sources/RunBot/UI/DesignSystem/Color+RunnerModel.swift
+++ b/Sources/RunBot/UI/DesignSystem/Color+RunnerModel.swift
@@ -7,8 +7,9 @@ import SwiftUI
 
 /// Design-system `Color` mapping for `RunnerModel.StatusColor`.
 ///
-/// Centralises the runner-status dot colour used by `LocalRunnersView`
-/// and `RunnerDetailSheet` (resolves #1643).
+/// Centralises the runner-status dot colour so the list row and the detail view
+/// cannot drift apart (resolves #1643). Consumed via `runner.statusColor.color`
+/// — currently from `LocalRunnerRowView`.
 extension RunnerModel.StatusColor {
     /// The design-system `Color` that represents this status category.
     ///

--- a/Sources/RunBot/UI/DesignSystem/ColorTokens.swift
+++ b/Sources/RunBot/UI/DesignSystem/ColorTokens.swift
@@ -169,14 +169,19 @@ extension Color {
     // MARK: Surface & Border Tokens
     //
     // DESIGN TOKEN NOTE:
-    // On macOS 26+ the panel chrome uses NSGlassEffectView which provides its own
-    // backdrop blur and tinting. Surface tokens must use near-zero opacity so the
-    // glass layer shows through. Pre-26 values use the existing vibrancy opacities.
+    // Surfaces are composited over a Liquid Glass layer: `SurfaceModifiers`
+    // applies `.glassEffect(.regular)`, which supplies its own backdrop blur and
+    // tinting. Surface tokens must therefore carry near-zero opacity so that
+    // glass layer shows through rather than being painted over.
     //
     // ⚠️ TRANSLUCENCY CONTRACT — DO NOT REMOVE THIS COMMENT.
-    // NSVisualEffectView uses .hudWindow (.behindWindow). MUST stay opacity < 1.0.
-    // ❌ NEVER set opacity 1.0 — kills vibrancy.
-    // ❌ NEVER switch PanelChrome material back to .popover — warm brown tint.
+    // ❌ NEVER set opacity 1.0 on these tokens — an opaque fill covers the glass
+    //    backdrop entirely and the surface renders as flat grey.
+    // ❌ NEVER hardcode a material behind them. The historical failure here was a
+    //    `.popover` material under the old AppKit panel chrome, which tinted every
+    //    surface warm brown. The panel is gone, but the rule generalises: the
+    //    backdrop is owned by `.glassEffect` in `SurfaceModifiers`, not by these
+    //    tokens, and not by whatever view happens to host them.
     // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
     //
     // FIX (#2098): Surface tokens now use `adaptiveGrayscale` instead of
@@ -287,7 +292,11 @@ extension Color {
         dark: (white: 1, alpha: 0.06)
     )
 
-    /// Adaptive stroke color for job-row cards in `InlineJobRowsView`.
+    /// Adaptive stroke color for job-row cards.
+    ///
+    /// Currently has no consumer — its original caller (`InlineJobRowsView`) was
+    /// removed in the AppShell migration and `JobRow` draws no stroke. Retained
+    /// pending the design-token cleanup; see #3028.
     /// Black 0.18 in light mode (replaces the previous fixed white, which was invisible);
     /// white 0.25 in dark mode (preserves the existing dark-mode stroke strength).
     ///

--- a/Sources/RunBot/UI/DesignSystem/MetricsTokens.swift
+++ b/Sources/RunBot/UI/DesignSystem/MetricsTokens.swift
@@ -9,11 +9,11 @@ enum RBMetrics {
     /// Scale factor applied to `ProgressView` in the update action row.
     /// 0.7 keeps the spinner visually consistent with the `.small` control size of adjacent buttons.
     static let updateProgressScale: CGFloat = 0.7
-    /// Maximum width for the commit/PR title label in `ActionRowView` (#2130).
+    /// Maximum width for the commit/PR title label in `WorkflowRow` (#2130).
     /// Caps the greedy `.layoutPriority(1)` text so it can't consume the full row width.
     /// The existing `.lineLimit(1)` + `.truncationMode(.tail)` produce an ellipsis at this cap.
     static let actionRowTitleMaxWidth: CGFloat = 160
-    /// Maximum width for the head-branch label in `ActionRowView`.
+    /// Maximum width for the head-branch label in `WorkflowRow`.
     /// Kept narrower than `actionRowTitleMaxWidth` since branch names are lower priority (#1194).
     static let actionRowBranchMaxWidth: CGFloat = 80
 }

--- a/Sources/RunBot/UI/Features/LocalRunners/AddRunner/AddRunnerSheet.swift
+++ b/Sources/RunBot/UI/Features/LocalRunners/AddRunner/AddRunnerSheet.swift
@@ -373,6 +373,15 @@ struct AddRunnerSheet: View {
         let name = registrationName
         let dir = registrationPath
 
+        // ⚠️ CONTAINMENT GUARD — the install path is user-editable text, and below we
+        // createDirectory, download into it, untar into it, and run config.sh from it.
+        // Confine all of that to the user's home directory. Two details are
+        // load-bearing and must not be "simplified":
+        //   1. Symlinks are resolved on BOTH sides. Comparing raw paths lets a
+        //      symlinked install dir point anywhere outside ~ while still passing.
+        //   2. The prefix test is `homeDir + "/"`, not `homeDir`. A bare
+        //      hasPrefix(homeDir) also accepts sibling paths that merely start with
+        //      the same characters — /Users/eve passes a check anchored on /Users/ev.
         let homeDir = FileManager.default.homeDirectoryForCurrentUser
             .resolvingSymlinksInPath().path
         let resolvedDir = URL(fileURLWithPath: dir).resolvingSymlinksInPath().path
@@ -382,6 +391,12 @@ struct AddRunnerSheet: View {
             return
         }
 
+        // Already-registered guard: a `.runner` file means this directory is a
+        // configured runner already, so re-running config.sh would fail or clobber it.
+        // Returns silently and deliberately — no errorMessage — because the common way
+        // to reach this is re-opening the sheet on an existing install, which is not a
+        // user error worth surfacing. If you are here because "nothing happens and no
+        // error shows", this is why; that is intended, not a missing error path.
         let runnerFile = URL(fileURLWithPath: dir).appendingPathComponent(".runner").path
         if FileManager.default.fileExists(atPath: runnerFile) {
             isRegistering = false
@@ -399,6 +414,10 @@ struct AddRunnerSheet: View {
 
         let configPath = URL(fileURLWithPath: dir).appendingPathComponent("config.sh").path
 
+        // Download + unpack only when config.sh is absent. This is what makes
+        // registering into a pre-existing (but unconfigured) runner directory
+        // idempotent: an interrupted earlier attempt that already unpacked the
+        // tarball resumes at the token step instead of re-downloading ~100 MB.
         if !FileManager.default.fileExists(atPath: configPath) {
             setStep("Downloading runner package…")
             guard let downloadURL = await fetchRunnerDownloadURL() else {
@@ -419,6 +438,8 @@ struct AddRunnerSheet: View {
             }
             setStep("Unpacking runner package…")
             let tarResult = await runSimpleProcess(GitHubURIs.tarPath, args: ["xzf", tarPath, "-C", dir])
+            // `try?` is deliberate: the tarball is scratch, and failing to delete it
+            // must not abort a registration that otherwise succeeded.
             try? FileManager.default.removeItem(atPath: tarPath)
             guard tarResult == 0 else {
                 isRegistering = false

--- a/Sources/RunBot/UI/Features/Scopes/AddScope/AddScopeSheet.swift
+++ b/Sources/RunBot/UI/Features/Scopes/AddScope/AddScopeSheet.swift
@@ -15,18 +15,21 @@ import SwiftUI
 /// GitHub API) with an explicit load-failure fallback, and Cancel / Add buttons.
 ///
 /// On confirmation calls `ScopeStore.shared.add(_:)`. No `onRestartPolling`
-/// callback is needed — `ScopeStore` mutation is observed by `RunnerStore`'s
+/// callback is needed — `ScopeStore` mutation is observed by `RunnerPoller`'s
 /// `withObservationTracking` loop, which triggers restart automatically.
 ///
 /// ## Why `.sheet` is on the root VStack, not the picker Button
 /// `RepoSelectorSheet` is presented via `.sheet(isPresented: $showRepoSelector)`
 /// and `.sheet(isPresented: $showOrgSelector)`.
-/// Attaching those modifiers to the `Button` (nested inside a `VStack`) constrains
-/// sheet presentation to the parent view bounds — i.e. the NSPopover panel size —
-/// instead of escaping to the window level. Lifting them to the root `VStack` causes
-/// AppKit to attach the sheet to `NSPopoverWindowFrame` directly, matching the
-/// behaviour of `AddRunnerSheet` and preserving compatibility with the legacy
-/// status-bar hierarchy that still reuses this sheet.
+/// Attaching those modifiers to the `Button` (nested inside a `VStack`) constrained
+/// sheet presentation to the parent view bounds instead of letting it escape to the
+/// window level; lifting them to the root `VStack` made AppKit attach the sheet to
+/// the hosting window frame directly, matching `AddRunnerSheet`.
+///
+/// That diagnosis was made against the menu-bar popover host, which no longer
+/// exists. The placement is kept because it is known-good and costs nothing, but
+/// the original mechanism no longer applies — revalidate before relying on this
+/// reasoning for a new sheet.
 /// ❌ NEVER move `.sheet(isPresented: $showRepoSelector)` or `.sheet(isPresented: $showOrgSelector)`
 /// back onto the individual Buttons.
 ///
@@ -34,7 +37,7 @@ import SwiftUI
 /// The content is a fixed set of controls (segmented picker, one field or button,
 /// helper caption) that never needs to scroll. A `ScrollView` prevents SwiftUI from
 /// computing a real `preferredContentSize` for the sheet window — it reports the
-/// container height (the NSPopover panel size) instead of the content height.
+/// container height instead of the content height.
 /// Replacing it with a plain `VStack` lets the sheet size itself intrinsically.
 /// ❌ NEVER wrap the content VStack in a ScrollView here.
 struct AddScopeSheet: View {
@@ -312,7 +315,7 @@ struct AddScopeSheet: View {
     }
 
     /// Persists `effectiveScope` to `ScopeStore` and dismisses the sheet.
-    /// Restart polling is driven automatically by `RunnerStore`'s
+    /// Restart polling is driven automatically by `RunnerPoller`'s
     /// `withObservationTracking` loop observing `ScopeStore` mutations.
     @MainActor private func confirmAdd() {
         let scope = effectiveScope

--- a/Sources/RunBot/UI/Features/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/UI/Features/Settings/Authentication/AuthenticationSection.swift
@@ -10,7 +10,7 @@ import SwiftUI
 ///
 /// Replaces the single-branch `accountSection` in `SettingsView+Sections.swift`.
 /// Reads `GitHubAuthentication` state directly and fires action callbacks so the
-/// parent (`SettingsView`) keeps ownership of service calls.
+/// parent (`SettingsDetailView`) keeps ownership of service calls.
 ///
 /// ## Layout (from #2892)
 /// Both cards stack vertically as full-width rows so titles never wrap.

--- a/Sources/RunBot/UI/Features/Workflows/Rows/TreeConnector.swift
+++ b/Sources/RunBot/UI/Features/Workflows/Rows/TreeConnector.swift
@@ -7,8 +7,8 @@ import SwiftUI
 ///
 /// Renders a straight bar with an elbow arrow pointing at the row content.
 /// For the last item in a group the bar stops at the elbow instead of
-/// continuing to the bottom edge. Simplified from the menu-bar
-/// `TreeLineLeader` (issue #2881) — no vertical-overlap bridging is needed
+/// continuing to the bottom edge. Simplified from the menu-bar era's since-deleted
+/// tree-line leader (issue #2881) — no vertical-overlap bridging is needed
 /// because hierarchy rows are stacked without card padding between segments.
 struct TreeConnector: View {
     /// Whether this is the last item in the group (bar stops at the elbow).

--- a/Sources/RunBot/UI/Features/Workflows/StepLog/LogCopyButton.swift
+++ b/Sources/RunBot/UI/Features/Workflows/StepLog/LogCopyButton.swift
@@ -4,7 +4,12 @@ import AppKit
 import RunBotCore
 import SwiftUI
 
-/// Top-bar copy button shared by ActionDetailView, JobDetailView, and StepLogView.
+/// Top-bar copy button for the step-log toolbar.
+///
+/// Originally shared by three popover-era detail views; those are gone and the
+/// only remaining consumer is `StepLogContentView`. Kept as a separate type
+/// because the copy/copied state machine is self-contained, not because it is
+/// currently reused.
 /// States: idle -> loading -> done (1.5 s) or failed (1.5 s) -> idle.
 struct LogCopyButton: View {
     /// Callback-based fetch. Invoke `completion` with the log text on success,

--- a/Sources/RunBot/UI/Features/Workflows/StepLog/StepLogContentView.swift
+++ b/Sources/RunBot/UI/Features/Workflows/StepLog/StepLogContentView.swift
@@ -15,10 +15,13 @@ private let markdownRenderLogger = Logger(
 
 /// Reusable step-log content view — fetch lifecycle, toolbar, metadata, and log body.
 ///
-/// Extracted from `StepLogView` so it can be embedded in both the panel-based
-/// popover UI and the windowed `StepLogPaneView` without duplication.
+/// Originally extracted from `StepLogView` so the same body could serve the
+/// menu-bar popover and the windowed shell. The popover is gone; the only
+/// production consumer is now `StepLogPaneView`, which hosts this view in the
+/// detail column of `AppNavigationSplitView`.
 ///
-/// Callers are responsible for the `maxHeight` cap on this view (ref #370).
+/// See the SIZING CONTRACT on `body` — the height cap and `idealWidth` are
+/// load-bearing and predate the windowed shell (ref #370, #375–377).
 @MainActor
 struct StepLogContentView: View {
     /// The job that owns this step.
@@ -67,18 +70,18 @@ struct StepLogContentView: View {
     /// the user explicitly toggles, this flag prevents `loadLog()` write-backs from
     /// overriding their choice during live refreshes.
     @State private var hasToggledMarkdown: Bool = false
-    /// `isMarkdownMode` alone can't distinguish "never set" from "user toggled off" —
-    /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
-    /// across step taps. `@State` would be discarded on every `.id(navState)`
-    /// remount in `RootPanelView` (SwiftUI tears down the full state tree when
-    /// the identity key changes, which happens on every step tap). By owning
-    /// `LogFetcher` in `AppState` and threading it down via `@Binding`, the
-    /// ZIP cache persists for the lifetime of the panel session: the second
-    /// step tap in the same run hits the cache and skips the network call.
+    /// Bound to the scene-owned `LogFetcher` so the ZIP cache survives across
+    /// step taps.
+    ///
+    /// `@State` would be discarded on every remount, and this view is remounted
+    /// on *every* step tap: `StepLogPaneView` applies
+    /// `.id(StepLogSelectionID(jobID:stepNumber:))`, and SwiftUI tears down the
+    /// full state tree when that identity changes. By owning `LogFetcher` in
+    /// `RunBotApp` (`@State private var logFetcher`) and threading it down via
+    /// `@Binding`, the ZIP cache persists for the lifetime of the scene: the
+    /// second step tap in the same run hits the cache and skips the network call.
     /// The snapshot/writeback pattern in `loadLog()` propagates cache updates
-    /// back to `AppState` through this binding on the MainActor after each fetch.
-    /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
-    /// across step taps.
+    /// back to the scene through this binding on the MainActor after each fetch.
     @Binding var logFetcher: LogFetcher
 
     /// Creates a `StepLogContentView` for the given job and step.
@@ -299,15 +302,33 @@ struct StepLogContentView: View {
                     }
                 }
             }
-            // ⚠️ REQUIRED -- caps preferredContentSize.height. Prevents panel growing off-screen.
+            // ⚠️ REQUIRED — caps the height this subtree reports to its parent.
+            // Without it the ScrollView reports the *full log text height* as its
+            // ideal height, which propagates up and grows the detail column (and
+            // in the popover era grew the panel off-screen — ref #370).
             // ❌ NEVER remove this modifier.
             .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
         }
         // ════════════════════════════════════════════════════════════════════════
-        // ⚠️ idealWidth: 480 hints the initial panel width before KVO fires.
-        // ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // ⚠️ SIZING CONTRACT — carried forward from the popover era.
+        //
+        // These rules were written for the NSPanel/NSHostingController host, which
+        // is gone. They still hold in the windowed shell, for a related reason:
+        // this view sits in the detail column of `AppNavigationSplitView`, and a
+        // subtree that reports an unbounded ideal size still pushes that column
+        // (and the window) around. See the SIZING CONTRACT on
+        // `AppNavigationSplitView` — ONE MEASUREMENT, ONE OWNER. This view is not
+        // the owner; it only bounds what it reports upward.
+        //
+        // ✔ idealWidth: 480 gives the subtree a natural width to report when the
+        //   parent offers a range rather than a fixed width.
+        // ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity) — the
+        //   maxHeight: .infinity corrupts width measurement when the host measures
+        //   this view unconstrained (the original AppKit defect behind #375/#376).
         // ❌ NEVER omit idealWidth: 480
         // ❌ NEVER add .frame(height:) or .fixedSize() here
+        // ❌ NEVER remove the ScrollView's .frame(maxHeight:) cap above (#370)
+        //
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
         // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment
         // is removed is major major major.

--- a/Sources/RunBot/UI/Features/Workflows/StepLog/StepLogView.swift
+++ b/Sources/RunBot/UI/Features/Workflows/StepLog/StepLogView.swift
@@ -6,42 +6,26 @@ import RunBotCore
 import SwiftUI
 
 // ╔════════════════════════════════════════════════════════════════════════════╗
-// ║ ☹️ StepLogView — LAYOUT + SIZING CONTRACT ☹️                              ║
+// ║ StepLogView — SUPERSEDED. Not reachable from the windowed shell.          ║
 // ╠════════════════════════════════════════════════════════════════════════════╣
-// ║ Navigation level 3 (PopoverMainView → JobDetailView → StepLogView).      ║
+// ║ This view was navigation level 3 of the menu-bar popover stack, pushed by ║
+// ║ a rootView swap on the old AppDelegate. That stack no longer exists: the  ║
+// ║ live path is                                                              ║
+// ║   AppNavigationSplitView → AppDetailColumnView → StepLogPaneView          ║
+// ║   → StepLogContentView                                                    ║
+// ║ and this type has no remaining call site (Periphery reports it unused).   ║
 // ║                                                                            ║
-// ║ LAYOUT RULES:                                                              ║
-// ║ • Root: .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)     ║
-// ║ • idealWidth: 480 hints SwiftUI's initial natural width measurement.      ║
-// ║   NSHostingController reads idealWidth as preferredContentSize.width      ║
-// ║   on the first layout pass (NSPanel architecture, not NSPopover).         ║
-// ║   The panel then resizes to content-driven width via KVO on               ║
-// ║   preferredContentSize (see AppDelegate.sizeObservation).                 ║
-// ║ • Log content MUST be inside the ScrollView.                              ║
-// ║ • Header MUST be outside the ScrollView (always visible, not scrolled).  ║
-// ║ ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity) — the      ║
-// ║   maxHeight: .infinity corrupts fittingSize.width when NSHostingCon-      ║
-// ║   troller measures the view unconstrained (AppKit bug, see #375 #376)     ║
-// ║ ❌ NEVER omit idealWidth: 480 from the root frame                         ║
-// ║ ❌ NEVER add .frame(height:) here                                         ║
-// ║ ❌ NEVER add .fixedSize() here                                            ║
-// ║ ✔ ScrollView MUST have .frame(maxHeight: visibleFrame * 0.75) cap        ║
-// ║   Without it, with sizingOptions=.preferredContentSize, SwiftUI           ║
-// ║   reports the full log text height as preferredContentSize.height on      ║
-// ║   navigate → panel grows off-screen. (ref #370)                           ║
-// ║ ❌ NEVER remove the .frame(maxHeight:) from the ScrollView                ║
-// ║                                                                            ║
-// ║ If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT     ║
-// ║ ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment   ║
-// ║ is removed is major major major.                                           ║
+// ║ ⚠️ The LAYOUT + SIZING CONTRACT that used to live here has been MIGRATED  ║
+// ║ to `StepLogContentView.body`, restated for the windowed shell. Read it    ║
+// ║ there, not here. Nothing is lost if this file is deleted — see the        ║
+// ║ dead-code cleanup issues (#3027 / #3028).                                 ║
 // ╙────────────────────────────────────────────────────────────────────────────╜
-// Phase 5: DesignToken colour sweep
-// Phase 7: meta badge backgrounds -> .glassCard(cornerRadius: RBRadius.small).
-/// Shows the raw log text for a single `GitHubStep`.
+/// Shows the raw log text for a single `GitHubStep`, wrapped in a back-navigation
+/// header.
 ///
-/// Placed by `AppDelegate.navigate()` (rootView swap). Fits the fixed popover frame;
-/// `ScrollView` absorbs overflow. Fetches log on `onAppear` via a background task;
-/// cancelled automatically on `onDisappear` to avoid wasted work on fast back-navigation.
+/// Superseded by `StepLogPaneView` in the windowed shell and retained only until
+/// the dead-code cleanup lands. `ScrollView` absorbs overflow; the fetch lifecycle
+/// belongs to the embedded `StepLogContentView`.
 @MainActor
 struct StepLogView: View {
     /// The job that owns this step.
@@ -60,23 +44,27 @@ struct StepLogView: View {
     /// Injected scope store — avoids `ScopeStore.shared` singleton access inside `loadLog`.
     /// Defaults to the live singleton so all existing call sites require no changes.
     var scopeStore: any ScopeStoreProtocol
-    /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
-    /// across step taps. Threading it down via `@Binding` keeps the ZIP cache
-    /// alive for the lifetime of the panel session; the snapshot/writeback
-    /// pattern in `StepLogContentView.loadLog()` propagates updates back.
+    /// Bound to the scene-owned `LogFetcher` so the ZIP cache survives across
+    /// step taps. Threading it down via `@Binding` keeps the ZIP cache alive for
+    /// the lifetime of the scene; the snapshot/writeback pattern in
+    /// `StepLogContentView.loadLog()` propagates updates back.
     @Binding var logFetcher: LogFetcher
 
     /// Creates a `StepLogView` for the given job step.
     /// - Parameters:
     ///   - job: The job that owns the step.
     ///   - step: The step whose log will be fetched and displayed.
+    ///   - logFetcher: Binding to the scene-owned `LogFetcher`, so the ZIP cache
+    ///     survives remounts. The `.constant(LogFetcher())` default is for previews
+    ///     and tests only — writes through a `.constant` binding are silently
+    ///     dropped, so every cache update would be lost.
     ///   - onBack: Called when the user taps the back button.
     ///   - onLogLoaded: Optional callback fired on the main thread once the log fetch completes.
     ///   - scopeStore: Scope store used for API scope resolution. Defaults to `ScopeStore.shared`.
     init(
         job: ActiveJob,
         step: GitHubStep,
-        logFetcher: Binding<LogFetcher> = .constant(LogFetcher()), // preview/test only — production callers must pass AppState's @Binding; .constant writes are silently dropped
+        logFetcher: Binding<LogFetcher> = .constant(LogFetcher()), // preview/test only — production callers must pass the scene's @Binding; .constant writes are silently dropped
         onBack: @escaping () -> Void,
         onLogLoaded: (() -> Void)? = nil,
         scopeStore: (any ScopeStoreProtocol)? = nil
@@ -119,19 +107,13 @@ struct StepLogView: View {
                 onLogLoaded: onLogLoaded,
                 scopeStore: scopeStore
             )
-            // ⚠️ REQUIRED -- caps preferredContentSize.height. Prevents panel growing off-screen.
+            // ⚠️ REQUIRED — caps reported height. See the SIZING CONTRACT on
+            // `StepLogContentView.body` for the canonical rule (ref #370).
             // ❌ NEVER remove this modifier.
             .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
         }
-        // ════════════════════════════════════════════════════════════════════════
-        // ⚠️ idealWidth: 480 hints the initial panel width before KVO fires.
-        // ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // ❌ NEVER omit idealWidth: 480
-        // ❌ NEVER add .frame(height:) or .fixedSize() here
-        // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
-        // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment
-        // is removed is major major major.
-        // ════════════════════════════════════════════════════════════════════════
+        // ⚠️ Mirrors the SIZING CONTRACT on `StepLogContentView.body`, which is the
+        // canonical copy. Do not edit these constraints here in isolation.
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
     }
 }

--- a/Sources/RunBot/UI/Navigation/SidebarMetrics/SidebarMetricsCard.swift
+++ b/Sources/RunBot/UI/Navigation/SidebarMetrics/SidebarMetricsCard.swift
@@ -33,8 +33,9 @@ enum SidebarMetricLayout {
 /// the window is short.
 ///
 /// ## Reuse
-/// Reuses `SystemStatsViewModel`, `SystemStats`, and `SparklineView`.
-/// Does not embed the full-page `SystemStatsView`.
+/// Reuses `SystemStatsViewModel`, `SystemStats`, and `SparklineView`. This is the
+/// only metrics surface in the app — the popover-era full-page stats view is gone,
+/// so these rows are the presentation, not a condensed version of one.
 @MainActor
 struct SidebarMetricsCard: View {
 

--- a/Sources/RunBot/UI/Shared/ScopeSelection/RepoSelectorSheet.swift
+++ b/Sources/RunBot/UI/Shared/ScopeSelection/RepoSelectorSheet.swift
@@ -7,8 +7,9 @@ import SwiftUI
 // #580 / #576: Reusable searchable sheet for picking a repository or organisation.
 //
 // Accepts a pre-loaded list of items (no API calls) and filters them
-// client-side via localizedCaseInsensitiveContains, matching the UX
-// pattern established by BranchSelectorSheet.
+// client-side via localizedCaseInsensitiveContains. This is now the only
+// selector sheet of its kind; the branch selector it was modelled on has since
+// been removed.
 //
 // Usage:
 // RepoSelectorSheet(

--- a/Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift
+++ b/Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift
@@ -8,7 +8,7 @@ import GitHubClient
 /// Bridges `GitHubLogger` (defined in `GitHubClient`) to the RunBot unified
 /// logging system (`log()` free function in Logger.swift).
 ///
-/// Passed to `GitHubClient` at construction time in `AppDelegate` so that
+/// Passed to `GitHubClient` at construction time in `RunBotRuntime.init` so that
 /// all `GitHubClient` diagnostic messages appear in the same `os.Logger`
 /// stream as the rest of the app, filtered under the matching category.
 ///

--- a/Sources/RunBotCore/Platform/LoginItem.swift
+++ b/Sources/RunBotCore/Platform/LoginItem.swift
@@ -14,7 +14,7 @@ public enum LoginItem {
     }
 
     /// Registers or unregisters launch-at-login based on `enabled`.
-    /// Called from the login-item toggle in `SettingsView` via the two-argument
+    /// Called from the login-item toggle in `GeneralSettingsSection` via the two-argument
     /// `onChange(of:)` form, which supplies the new toggle value directly.
     /// Errors are logged to stderr but otherwise swallowed — failure is non-fatal
     /// since the toggle will reflect the unchanged state via `LoginItem.isEnabled`.

--- a/Sources/RunBotCore/Platform/ProcessRunner.swift
+++ b/Sources/RunBotCore/Platform/ProcessRunner.swift
@@ -35,6 +35,8 @@ import os
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {
+    // MARK: - Result
+
     /// The collected output and exit status from a subprocess invocation.
     public struct Result {
         /// Collected stdout bytes, or `nil` when the process failed to launch

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -48,7 +48,7 @@ import SwiftUI
 ///
 /// ## betaChannel — why stored var, not computed or @AppStorage
 /// `betaChannel` MUST be `@Observable`-tracked so that `.onChange(of: settings.betaChannel)`
-/// fires in `SettingsView+Sections.betaChannelRow`.
+/// fires in `UpdateSettingsSection.betaChannelRow`.
 ///
 /// **Why not `@ObservationIgnored @AppStorage`:**
 /// `@ObservationIgnored` suppresses `withMutation(keyPath:)` in the setter, so
@@ -116,9 +116,12 @@ public final class AppPreferencesStore {
     @AppStorage(AppPreferencesStore.keyShowDimmedRunners)
     public var showDimmedRunners: Bool = true
 
-    /// INERT — has no effect since PR #2305 replaced NSPopover with an owned panel.
-    /// Preserved here to avoid removing a user-visible Settings toggle in the same PR.
-    /// Either wire to something meaningful or remove in a follow-up.
+    /// INERT — has no effect. #2305 replaced the `NSPopover` this controlled with an
+    /// owned panel, and the AppShell migration then replaced that panel with a plain
+    /// `Window`; there has been no popover arrow to show or hide for two architectures.
+    /// Preserved only to avoid silently dropping a persisted user default. It is not
+    /// read anywhere — wire it to something meaningful or remove it along with the
+    /// Settings toggle. Tracked in #3029.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowPopoverArrow)
     public var showPopoverArrow: Bool = true
@@ -173,7 +176,7 @@ public final class AppPreferencesStore {
     ///
     /// Defaults to `true`. Follows the same stored-var + `didSet` pattern as
     /// `betaChannel` so `.onChange(of: settings.automaticUpdatesEnabled)` fires
-    /// correctly in `SettingsView`. See class-level `## betaChannel — why stored
+    /// correctly in `UpdateSettingsSection`. See class-level `## betaChannel — why stored
     /// var, not computed or @AppStorage` for the rationale.
     public var automaticUpdatesEnabled: Bool = true {
         didSet {

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -20,7 +20,7 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// `true` for recently-completed jobs shown as faded history entries.
     public let isDimmed: Bool
     /// The repo or org scope string this job belongs to.
-    /// Always `nil` at decode time — injected post-fetch by `RunnerStore`.
+    /// Always `nil` at decode time — injected post-fetch by `RunnerPoller`.
     public let scope: String?
 
     // Override slots — used only by asCompleted to freeze status/conclusion.

--- a/Sources/RunBotCore/Runner/Models/RunnerModel.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerModel.swift
@@ -49,7 +49,7 @@ public struct RunnerModel: Sendable, Identifiable, Equatable {
     /// Populated by `RunnerStatusEnricher.applyEnrichment` after the first
     /// enrichment cycle. `nil` until enrichment has run at least once.
     ///
-    /// Used by `RunnerStore.buildInstallPathMap` to build the `byApiId` lookup
+    /// Used by `RunnerPoller.buildInstallPathMap` to build the `byApiId` lookup
     /// map so that metrics can be matched for org runners whose local `agentId`
     /// does not match the GitHub API id.
     public let apiId: Int?
@@ -227,7 +227,9 @@ public struct RunnerModel: Sendable, Identifiable, Equatable {
         }
     }
 
-    /// Dot colour category used by `SettingsView.localRunnerDotColor(for:)`.
+    /// Dot colour category. Mapped to a design-system `Color` by the
+    /// `RunnerModel.StatusColor` extension in the app target and rendered by
+    /// `LocalRunnerRowView`.
     public var statusColor: StatusColor {
         switch resolvedState {
         case .warning: return .offline

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -43,8 +43,8 @@ extension WorkflowActionGroup {
 /// `group_runs()` + `enrich_group()`.
 ///
 /// Hierarchy: `WorkflowActionGroup` → jobs (flat across all sibling runs) → `JobStep` → log.
-/// `ActionDetailView` drills into the flat job list; `JobDetailView`/`StepLogView`
-/// are reused unchanged below that.
+/// `WorkflowHierarchyView` renders the whole tree inline in the content column;
+/// `StepLogPaneView` renders the selected step's log in the detail column.
 public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// The git commit SHA that triggered this group of runs.
     public let headSha: String
@@ -99,7 +99,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public var latestRunID: Int { runs.map { $0.id }.max() ?? 0 }
 
     /// All jobs across every run in this group, fetched and flattened.
-    /// This is what `ActionDetailView` renders.
+    /// This is what `WorkflowHierarchyView` expands under each workflow row.
     public let jobs: [ActiveJob]
 
     /// UTC time of the earliest job `startedAt` across all runs.
@@ -141,13 +141,13 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     // `id` remains stable across polls, so `List`/`ForEach` still diff groups as
     // in-place updates rather than remove+insert pairs (#2688 stays fixed).
     //
-    // Cost note: `onChange(of: store.actions)` in `PanelMainView` now deep-compares
+    // Cost note: `onChange(of: runnerState.actions)` in `WorkflowHierarchyView` deep-compares
     // job arrays once per poll snapshot. The lists involved are tens of value
     // structs — negligible next to the network fetch that produced them.
 
     /// Returns a copy of this group with a replacement jobs array.
     ///
-    /// Used in `RunnerStore` to enrich job data without reconstructing the
+    /// Used in `RunnerPoller` to enrich job data without reconstructing the
     /// full struct at every call site.
     public func withJobs(_ newJobs: [ActiveJob]) -> WorkflowActionGroup {
         WorkflowActionGroup(

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -9,7 +9,7 @@ import Foundation
 ///
 /// All methods are static and operate only on data passed as parameters.
 /// Fetch / API side-effects are injected as closures so this type is
-/// independently unit-testable without a RunnerStore instance.
+/// independently unit-testable without a RunnerPoller instance.
 public enum PollResultBuilder {
 
   // MARK: - Cache limits

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller+Backfill.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller+Backfill.swift
@@ -24,8 +24,10 @@ extension RunnerPoller {
     ///    warning spam. They re-enter the cache with correct scope data on the next
     ///    poll cycle once a new live fetch completes. This flash is cosmetic and
     ///    self-corrects within one poll cycle.
-    ///    TODO: Remove this guard after two release cycles once pre-F-26 cache
-    ///    entries are definitively gone from the field.
+    ///    TODO(#3029): Remove this guard once pre-F-26 caches are gone from the
+    ///    field. Concretely: it is safe to delete when no supported release still
+    ///    writes `scope == nil` entries — check the two most recent tagged releases
+    ///    before removing, rather than counting cycles from an unrecorded start.
     ///
     /// 2. **Org-only scope (`!scope.contains("/")`)**
     ///    The GitHub Jobs API has no `orgs/{org}/actions/jobs/{id}` endpoint — only

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller+FetchHelpers.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller+FetchHelpers.swift
@@ -43,8 +43,12 @@ extension RunnerPoller {
 
   /// Fetches workflow action groups for the given scopes concurrently.
   ///
-  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU window.
+  /// - Parameters:
+  ///   - scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///     directly to avoid re-reading `scopeStore.activeScopes` and creating a
+  ///     TOCTOU window.
+  ///   - shaKeyedCache: Previously-fetched groups keyed by head SHA, forwarded to
+  ///     each per-scope fetch so already-known groups are not re-enriched.
   ///
   /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`.
   func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller+PollBridge.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller+PollBridge.swift
@@ -38,9 +38,12 @@ extension RunnerPoller {
     /// Builds a `JobPollResult` by fetching live jobs for all monitored scopes,
     /// backfilling step data from the cache, and diffing against `snapPrev`.
     ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal`, threaded
-    ///   through to `fetchAllJobs(scopes:)` to avoid a TOCTOU re-read of
-    ///   `scopeStore.activeScopes`.
+    /// - Parameters:
+    ///   - snapPrev: Live-job snapshot from the previous poll, used to diff.
+    ///   - snapCache: Completed-job cache from the previous poll; backfilled in place.
+    ///   - scopes: The scope snapshot captured by `fetchInternal`, threaded
+    ///     through to `fetchAllJobs(scopes:)` to avoid a TOCTOU re-read of
+    ///     `scopeStore.activeScopes`.
     func buildJobState(
         snapPrev: [Int: ActiveJob],
         snapCache: [Int: ActiveJob],
@@ -67,9 +70,13 @@ extension RunnerPoller {
     /// Builds a `GroupPollResult` by fetching live workflow action groups for all monitored scopes,
     /// enriching jobs from the job cache, and diffing against `snapPrevGroups`.
     ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal`, threaded
-    ///   through to `fetchActionGroups(scopes:shaKeyedCache:)` to avoid a TOCTOU re-read
-    ///   of `scopeStore.activeScopes`.
+    /// - Parameters:
+    ///   - snapPrevGroups: Live-group snapshot from the previous poll, used to diff.
+    ///   - snapGroupCache: Completed-group cache from the previous poll.
+    ///   - jobCache: Completed-job cache used to enrich each group's job list.
+    ///   - scopes: The scope snapshot captured by `fetchInternal`, threaded
+    ///     through to `fetchActionGroups(scopes:shaKeyedCache:)` to avoid a TOCTOU
+    ///     re-read of `scopeStore.activeScopes`.
     func buildGroupState(
         snapPrevGroups: [String: WorkflowActionGroup],
         snapGroupCache: [String: WorkflowActionGroup],

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller/RunnerPoller.swift
@@ -136,7 +136,7 @@ public actor RunnerPoller {
   /// No longer drives poll cadence (removed in Step 4 of #2069 — `preferencesStore.pollingInterval`
   /// replaced by `PollIntervalStrategy`). Step 10 (#2073) removed `pollingInterval` from the
   /// protocol; this property is now dead inside `RunnerPoller`. Pending removal together
-  /// with its `AppState` injection site in a follow-up cleanup.
+  /// with its injection site in `RunBotRuntime.init` in a follow-up cleanup.
   let preferencesStore: any AppPreferencesStoreProtocol
   /// Injected scope store. Provides `activeScopes`.
   /// `internal` (not `private`) so that extension files can read this property.
@@ -181,8 +181,13 @@ public actor RunnerPoller {
   ///   - notificationPreferences: Notification preference store used to gate dispatch.
   ///     Pass `.shared` in production; pass an ephemeral instance in tests.
   ///   - actionGroupFetcher: Fetcher for workflow action groups.
-  ///   - zipPrefetchQueue: Background ZIP prefetch queue. Defaults to a shared instance;
-  ///     inject a stub in tests.
+  ///   - diskZIPCache: Shared on-disk ZIP cache. Note the interaction with the next
+  ///     parameter: when `zipPrefetchQueue` is `nil` this cache is threaded into the
+  ///     queue that gets built here, but when a `zipPrefetchQueue` **is** supplied it
+  ///     carries its own cache and this argument only sets the actor's own property.
+  ///     Passing both and expecting them to be the same cache is a mistake.
+  ///   - zipPrefetchQueue: Background ZIP prefetch queue. Defaults to one built over
+  ///     `diskZIPCache`; inject a stub in tests.
   public init(
     state: RunnerState,
     preferencesStore: any AppPreferencesStoreProtocol,

--- a/Sources/RunBotCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerLifecycleService.swift
@@ -145,6 +145,12 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
         }
         let dir = URL(fileURLWithPath: path)
 
+        // Step 1 is best-effort and its result is deliberately NOT propagated:
+        // `svcOk` is logged and then only re-reported in the final summary line. A
+        // runner whose LaunchAgent was already unloaded (or never installed) fails
+        // here harmlessly, and blocking deregistration on that would strand the
+        // runner as registered on GitHub with no local way to remove it.
+        // ❌ Do not "fix" this by returning early when svcOk is false.
         logStep("REMOVE", "step1: svc.sh uninstall")
         let (svcOk, _) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["uninstall"],

--- a/Sources/RunBotCore/Runner/Services/RunnerLifecycleServiceProtocol.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerLifecycleServiceProtocol.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// Abstraction over macOS launchctl runner lifecycle operations (start, stop, remove).
 ///
-/// Introduced so `LocalRunnersView` and any future consumers can depend on the
+/// Introduced so the local-runner UI and any future consumers can depend on the
 /// protocol rather than the concrete `RunnerLifecycleService`, enabling unit testing
 /// with a stub that does not spawn real `svc.sh` processes.
 ///

--- a/Sources/RunBotCore/Runner/Services/RunnerStatusEnricher.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerStatusEnricher.swift
@@ -48,7 +48,7 @@ private struct RunnerPayload: Decodable, Sendable {
     /// The GitHub REST API numeric runner ID.
     ///
     /// Stored as `RunnerModel.apiId` after enrichment so that
-    /// `RunnerStore.buildInstallPathMap` can build a `byApiId` lookup map —
+    /// `RunnerPoller.buildInstallPathMap` can build a `byApiId` lookup map —
     /// enabling metrics resolution for org runners whose local `.runner` JSON
     /// `AgentId` differs from this GitHub-assigned id.
     let id: Int?

--- a/Sources/RunBotCore/Runner/Services/RunnerViewModelProtocol.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerViewModelProtocol.swift
@@ -9,8 +9,9 @@ import Foundation
 ///
 /// Declaring the protocol in `RunBotCore` (rather than the app target) achieves two goals:
 /// 1. `RunnerPoller` and `LocalRunnerStore` can reference it without importing AppKit or SwiftUI.
-/// 2. Test doubles (`MockRunnerViewModel`) can be defined inside `RunBotCoreTests` and
-///    passed into the actors without any app-target dependency.
+/// 2. Test doubles can be defined inside `RunBotCoreTests` and passed into the
+///    actors without any app-target dependency. (The original `MockRunnerViewModel`
+///    has since been removed; the point stands for any future double.)
 ///
 /// **Direction of data flow:** stores *push* into the receiver; the receiver never pulls.
 /// All mutations arrive on `@MainActor` via `await MainActor.run { }`.

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher/WorkflowActionGroupFetcher.swift
@@ -53,7 +53,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
   /// Date parsing goes through `ISO8601DateParser.shared` — one actor, one formatter.
   ///
   /// - Note: `@concurrent` is applied only to this public entry point so that
-  ///   callers on an actor-bound context (e.g. `RunnerStore`'s custom actor executor) hop
+  ///   callers on an actor-bound context (e.g. `RunnerPoller`'s custom actor executor) hop
   ///   off the actor executor for the entire fetch pipeline. The private helpers
   ///   (`buildActionGroup`, `fetchJobsForGroup`, `fetchJobsForRun`) are internal
   ///   to `withTaskGroup` and already run on the task's executor, so they don't

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher/WorkflowActionGroupFetcherProtocol.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher/WorkflowActionGroupFetcherProtocol.swift
@@ -1,13 +1,13 @@
 // WorkflowActionGroupFetcherProtocol.swift
 // RunBotCore
 //
-// Protocol allowing RunnerStore to store an existential instead of a concrete
-// WorkflowActionGroupFetcher, making future RunnerStore integration tests easier
+// Protocol allowing RunnerPoller to store an existential instead of a concrete
+// WorkflowActionGroupFetcher, making future RunnerPoller integration tests easier
 // to write (a stub conformer can return a predetermined [WorkflowActionGroup]
 // without wiring up an HTTP stub).
 //
 // - Note: `Sendable` conformance is required so the existential can be stored as
-//   a `let` inside `RunnerStore` (a custom `actor`) without triggering
+//   a `let` inside `RunnerPoller` (a custom `actor`) without triggering
 //   non-Sendable-capture warnings at the actor boundary.
 import Foundation
 
@@ -15,13 +15,13 @@ import Foundation
 
 /// Abstraction over fetching and grouping workflow action groups.
 ///
-/// Introduced so that `RunnerStore` depends on an injected fetcher instead of
+/// Introduced so that `RunnerPoller` depends on an injected fetcher instead of
 /// the concrete `WorkflowActionGroupFetcher`, enabling future unit tests of
-/// `RunnerStore` itself to supply a stub that returns predetermined groups.
+/// `RunnerPoller` itself to supply a stub that returns predetermined groups.
 ///
 /// ## Production usage
 /// ```swift
-/// RunnerStore(…, actionGroupFetcher: WorkflowActionGroupFetcher())
+/// RunnerPoller(…, actionGroupFetcher: WorkflowActionGroupFetcher())
 /// ```
 ///
 /// ## Test double

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerStore.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerStore.swift
@@ -255,10 +255,10 @@ public actor LocalRunnerStore {
 
     /// Fire-and-forget refresh. Spawns a Task and returns immediately.
     ///
-    /// Use this from views and on-demand callers (e.g. SettingsView lifecycle actions)
+    /// Use this from views and on-demand callers (e.g. runner lifecycle actions)
     /// that do not need to wait for completion.
     ///
-    /// At app startup, prefer `refreshAsync()` so that `RunnerStore.start()` is only
+    /// At app startup, prefer `refreshAsync()` so that `RunnerPoller.start()` is only
     /// called after `runners` is fully populated — ensuring cycle-1 `installPathMap`
     /// is never empty and metrics appear on first runner appearance.
     public func refresh() {

--- a/Sources/RunBotCore/Runner/UseCases/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunBotCore/Runner/UseCases/SaveRunnerEditsUseCase.swift
@@ -203,8 +203,9 @@ public struct SaveRunnerEditsUseCase: Sendable {
 
     /// Validates the prerequisites for the labels API call and extracts the scope string.
     ///
-    /// Delegates path extraction to the canonical `scopeFromUrl(_:)` in
-    /// `GitHubURLHelpers` (F-52), replacing the previous inline `pathComponents` slice.
+    /// Delegates path extraction to the canonical `scopeFromUrl(_:)` in the
+    /// `GitHubClient` package (`GitHubURLParsing.swift`, F-52), replacing the
+    /// previous inline `pathComponents` slice.
     ///
     /// - Returns: `.success((agentId, scope))` when both fields are present;
     ///   `.failure(LabelsPrerequisiteError)` identifying the first missing field.

--- a/Sources/RunBotCore/Scopes/ScopeEntry.swift
+++ b/Sources/RunBotCore/Scopes/ScopeEntry.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A single watched GitHub scope (repo or org) with an enable/disable flag.
 ///
 /// `scope` is either `"owner/repo"` (repository) or `"myorg"` (organisation).
-/// `isEnabled` controls whether `RunnerStore` polls this scope; disabled scopes
+/// `isEnabled` controls whether `RunnerPoller` polls this scope; disabled scopes
 /// are retained in the list but silently skipped during fetch.
 ///
 /// ## Equatable / Hashable — displayName excluded
@@ -25,7 +25,7 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// `let`: the scope string is immutable after construction. To change a scope,
     /// remove the existing entry and add a new one via `ScopeStore`.
     public let scope: String
-    /// When `false`, `RunnerStore` skips this scope during polling.
+    /// When `false`, `RunnerPoller` skips this scope during polling.
     /// `let`: use `copying(isEnabled:)` to derive a toggled copy — the only intended
     /// mutation site is `ScopeStore.setEnabled(_:_:)`.
     public let isEnabled: Bool

--- a/Sources/RunBotCore/Scopes/ScopePreferencesStore.swift
+++ b/Sources/RunBotCore/Scopes/ScopePreferencesStore.swift
@@ -115,7 +115,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
   /// Returns the full `ScopePreferences` snapshot for `scope` in a single actor hop.
   ///
   /// This is the preferred read path when multiple fields are needed at once
-  /// (e.g. seeding `ScopeEditSheet` draft state). One `await` instead of N.
+  /// (e.g. seeding scope-editor draft state). One `await` instead of N.
   public func preferences(for scope: String) -> ScopePreferences {
     read(scope: scope)
   }
@@ -123,7 +123,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
   /// Writes a complete `ScopePreferences` snapshot for `scope` in a single actor hop.
   ///
   /// This is the preferred write path when multiple fields need to be committed
-  /// atomically (e.g. `ScopeEditSheet.confirmSave()`). One `await` and one
+  /// atomically (e.g. a scope editor's save action). One `await` and one
   /// encode/write instead of N sequential read-modify-write cycles.
   ///
   /// - Important: Do not call `preferences(for:)` and then `setPreferences(_:for:)`

--- a/Sources/RunBotCore/Scopes/ScopePreferencesStoreProtocol.swift
+++ b/Sources/RunBotCore/Scopes/ScopePreferencesStoreProtocol.swift
@@ -15,7 +15,7 @@ public protocol ScopePreferencesStoreProtocol: Actor {
     /// Returns a full `ScopePreferences` snapshot for the scope in one actor hop.
     ///
     /// Prefer this over calling individual getters in sequence when multiple fields
-    /// are needed at once (e.g. before presenting `ScopeEditSheet`) — one `await`
+    /// are needed at once (e.g. before presenting a scope editor) — one `await`
     /// instead of N. The returned value is a value-type copy and is safe to use
     /// outside the actor.
     func preferences(for scope: String) -> ScopePreferences

--- a/Sources/RunBotCore/Scopes/ScopeStore.swift
+++ b/Sources/RunBotCore/Scopes/ScopeStore.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// Persists the list of watched GitHub scopes as `[ScopeEntry]` in `UserDefaults`.
 ///
-/// Mutations update the `@Observable` `entries` array; `RunnerStore` observes
+/// Mutations update the `@Observable` `entries` array; `RunnerPoller` observes
 /// `activeScopes` via `withObservationTracking`/`AsyncStream` (no Combine bridge).
 @MainActor
 @Observable
@@ -32,7 +32,7 @@ public final class ScopeStore {
   /// the only other write path; it assigns during initialisation only.
   public private(set) var entries: [ScopeEntry] = []
 
-  /// Scopes that are currently enabled — used by `RunnerStore` for polling.
+  /// Scopes that are currently enabled — used by `RunnerPoller` for polling.
   public var activeScopes: [String] { entries.filter(\.isEnabled).map(\.scope) }
 
   /// Designated initialiser.
@@ -109,7 +109,7 @@ public final class ScopeStore {
   }
 
   /// Toggles the `isEnabled` flag for the entry with the given ID and persists
-  /// the change. `RunnerStore` observes `activeScopes` via `withObservationTracking`,
+  /// the change. `RunnerPoller` observes `activeScopes` via `withObservationTracking`,
   /// so replacing the element in the `@Observable` `entries` array triggers a
   /// poll-loop restart.
   public func setEnabled(_ id: UUID, _ enabled: Bool) {
@@ -127,9 +127,8 @@ public final class ScopeStore {
 
   /// Re-hydrates the transient `displayName` on every entry from `ScopePreferencesStore`.
   ///
-  /// Call this once after launch (from `AppDelegate+StoreSetup`) and again after
-  /// `ScopeEditSheet` saves new preferences, so `ScopesView` reflects alias changes
-  /// without requiring a full restart. Runs on `@MainActor`; the actor hop to
+  /// Call this once after launch and again whenever scope preferences are saved,
+  /// so the scope list reflects alias changes without requiring a full restart. Runs on `@MainActor`; the actor hop to
   /// `ScopePreferencesStore` is handled by `preferences(for:)`.
   ///
   /// ## Concurrency safety

--- a/Sources/RunBotCore/Utilities/Bundle+Version.swift
+++ b/Sources/RunBotCore/Utilities/Bundle+Version.swift
@@ -63,7 +63,7 @@ extension Bundle {
     ///
     /// ## Why the call site uses `Bundle.main.isPreReleaseBuild`, not `appVersion.contains("-")`
     ///
-    /// REVIEWER: `aboutSection` in `SettingsView+Sections.swift` uses this property
+    /// REVIEWER: `AboutSettingsSection` uses this property
     /// directly rather than re-implementing `contains("-")` inline against `appVersion`.
     /// Both produce identical runtime output today (both read `rbVersionString`), but
     /// this property is the purpose-built API: the detection logic, all edge case docs,
@@ -103,7 +103,7 @@ extension Bundle {
     /// Returns `true` when `version` is strictly newer than the running bundle's
     /// `RBVersionString`.
     ///
-    /// Uses the same `ParsedVersion` comparison logic as `UpdateChecker` so beta
+    /// Delegates to `UpdateChecker.isNewer(_:than:)` so beta
     /// ordering is consistent throughout the app.
     ///
     /// ```swift

--- a/Sources/RunBotCore/Utilities/FormatElapsed.swift
+++ b/Sources/RunBotCore/Utilities/FormatElapsed.swift
@@ -11,9 +11,11 @@ import Foundation
 ///
 /// - Parameters:
 ///   - start: The start date, or `nil` if timing data is unavailable.
-///   - end:   The end date, or `nil` to use `Date()` (i.e. still running).
+///   - end:   The end date, or `nil` to fall back to `now` (i.e. still running).
 ///   - isCompleted: When `true` and `start` is `nil`, returns `"--:--"`
 ///     (timing data unavailable) instead of `"00:00"` (not yet started).
+///   - now: The reference "current time" used when `end` is `nil`. Defaults to
+///     `Date()`; inject a fixed date in tests so elapsed output is deterministic.
 /// - Returns: A `mm:ss` string such as `"02:47"`, or a sentinel value
 ///   (`"--:--"` / `"00:00"`) when timing data is absent.
 public func formatElapsed(

--- a/Sources/RunBotCore/Utilities/Logger.swift
+++ b/Sources/RunBotCore/Utilities/Logger.swift
@@ -16,7 +16,7 @@ import os
 /// and `log stream --predicate`.
 ///
 /// **Access level:** `public` because the app target (`Sources/RunBot/**`)
-/// calls `log()` directly from `AppDelegate`, views, and sheets.
+/// calls `log()` directly from the app runtime, views, and sheets.
 /// `internal` would cause a compile error in the app target.
 ///
 /// **Raw value convention:** all raw values are lowercase kebab-case so

--- a/Sources/RunBotCore/WorkflowLogs/Fetching/LogFetcher.swift
+++ b/Sources/RunBotCore/WorkflowLogs/Fetching/LogFetcher.swift
@@ -139,6 +139,13 @@ public struct LogFetcher: Sendable {
     /// - Parameters:
     ///   - runID: The GitHub workflow run ID (from `job.runID`).
     ///   - startedAt: Raw ISO 8601 start string (reserved for future use — currently unused in cache key).
+    ///   - runAttempt: The run attempt number (1-based). Part of the ZIP identity —
+    ///     a re-run produces different logs for the same `runID`, so attempts must
+    ///     not share a cache entry.
+    ///   - cacheGroup: Optional group key (`repo` + `headSha` + `normalizedEvent`)
+    ///     used to bucket ZIPs on disk so a whole commit's archives can be evicted
+    ///     together. When non-`nil`, a ZIP that fails extraction evicts the entire
+    ///     group rather than the single entry. Pass `nil` to opt out of grouping.
     ///   - jobID: The GitHub Actions job ID used for the flat-blob fallback path.
     ///   - jobName: The job display name (from `job.name`). Sanitised before ZIP lookup.
     ///   - step: The `GitHubStep` whose log is requested.

--- a/Tests/RunBotCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestDoubles.swift
@@ -126,9 +126,12 @@ actor SpyProxyStore: RunnerProxyStoreProtocol {
 /// writes are no-ops. It exists only to satisfy the protocol at the call site
 /// for tests that do not exercise state round-trips.
 ///
-/// For tests that need real state persistence, use `FakeScopePreferencesStore`
-/// in `ScopeEditSheetTests.swift`, which has a backing `[String: ScopePreferences]`
-/// store and a write log.
+/// There is currently **no stateful double** for this protocol. `ScopeEditSheetTests`
+/// used to provide `FakeScopePreferencesStore` — a backing
+/// `[String: ScopePreferences]` dictionary plus a write log — but both that fixture
+/// and its test file were removed with `ScopeEditSheet` in the AppShell migration.
+/// A test that needs state round-trips must add its own double; do not assume this
+/// one records writes.
 actor MockScopePreferencesStore: ScopePreferencesStoreProtocol {
     func preferences(for _: String) -> ScopePreferences { ScopePreferences() }
     func setPreferences(_: ScopePreferences, for _: String) {
@@ -155,8 +158,9 @@ actor MockScopePreferencesStore: ScopePreferencesStoreProtocol {
         // Intentionally empty: nothing to clean up in a stateless mock.
     }
     // Intentionally does not write back — this mock is stateless by design.
-    // `setPreferences` is also a no-op here. If you need state persistence,
-    // use `FakeScopePreferencesStore` instead.
+    // `setPreferences` is also a no-op here, so the mutation below is applied to a
+    // throwaway value and discarded. If you need state persistence, write a
+    // stateful double (see the type doc — there is no shared one).
     func modifyPreferences(for scope: String, with mutation: @Sendable (inout ScopePreferences) -> Void) {
         var prefs = preferences(for: scope)
         mutation(&prefs)

--- a/Tests/RunBotCoreTests/WorkflowLogs/Fetching/FetchStepLogTests.swift
+++ b/Tests/RunBotCoreTests/WorkflowLogs/Fetching/FetchStepLogTests.swift
@@ -15,16 +15,19 @@
 // (in that case unzipBinaryExists stays true but fetchStepLog returns something other
 // than .slice, which the !isSlice arm catches).
 //
-// Coverage map:
-//   Normal step — timestamp stripped, ANSI preserved         — test_normalStep_returnsSlice
-//   Regression #2358 — synthetic "Complete job" step (stub)  — test_completeJob_regression2358
-//   Regression #2358 — real extractor against fixture ZIP    — test_completeJob_regression2358_realExtractor
-//   Prefix match when filename differs from step.name        — test_sanitisedFilenameDiffers_prefixMatchSucceeds
-//   Whitespace-only content → .syntheticEmpty                — test_emptyContent_returnsSyntheticEmpty
-//   Only top-level blobs (no '/') → .flatBlobFallback        — test_onlyTopLevelBlobs_returnsFlatBlobFallback
-//   Job name with / and : sanitised                          — test_jobNameWithSlashAndColon_sanitised
-//   Job name > 90 UTF-16 code units truncated                — test_jobNameExceeds90UTF16Units_truncated
-//   Cache hit: zero extra network calls                      — test_cacheHit_zeroAdditionalNetworkCalls
+// Coverage areas (every test carries a descriptive @Test display name — read those
+// for the per-test detail rather than maintaining a duplicate index here, which is
+// how the previous hand-written coverage map silently drifted out of sync):
+//
+//   • StepLogResult cases — .slice, .syntheticEmpty (incl. isSkipped),
+//     .flatBlobFallback
+//   • Content correctness — timestamp prefixes stripped, ANSI escapes preserved
+//   • Regression #2358 — synthetic "Complete job" step with no ##[group] markers,
+//     exercised against the real extractor and the fixture ZIP
+//   • Request shaping — runAttempt reaches the attempts/N/logs endpoint
+//   • Caching — a repeat call for the same runID makes zero extra network calls
+//   • sanitizeJobNameForZIP — slash and Windows-invalid character stripping,
+//     90-UTF-16-unit truncation, and surrogate-pair safety at the cut boundary
 
 import Foundation
 import GitHubClient

--- a/Tests/RunBotUITests/RunBotUITests.swift
+++ b/Tests/RunBotUITests/RunBotUITests.swift
@@ -5,7 +5,13 @@
 // Runs on the self-hosted runner via xcodebuild.
 //
 // Design:
-//   • AppDelegate sets .regular activation policy + activate() when UI_TESTING is set.
+//   • The app sets .regular activation policy + activate() when UI_TESTING is set.
+//
+// ⚠️ STALE-ASSUMPTION WARNING: every constraint below was written against the
+//    menu-bar NSPanel host, which the AppShell migration replaced with a plain
+//    SwiftUI `Window`. These rules are retained because they encode real, hard-won
+//    failures, but they have NOT been revalidated against the windowed shell.
+//    Confirm on the self-hosted runner before trusting or deleting any of them.
 //
 // ⚠️ app.windows does NOT enumerate NSPanel with [.borderless, .nonactivatingPanel].
 //    ❌ NEVER use app.windows. Use app.staticTexts / app.buttons directly.

--- a/scripts/check-comment-symbols.py
+++ b/scripts/check-comment-symbols.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Fail when a code comment references a `BacktickedType` that no longer exists.
+
+Comments rot silently. A rename or deletion updates every call site — the compiler
+insists — but leaves the prose pointing at a symbol nobody can find. The AppShell
+migration left 69 such references across 38 files (#3029), including several
+"DO NOT REMOVE" regression guards that named deleted types. A guard whose stated
+reason is falsifiable is worse than no guard at all, because the next reader checks
+the claim, finds nothing, and discounts the whole block.
+
+Scope, and the limits that keep it quiet enough to leave on:
+
+  * Only CamelCase identifiers inside `backticks`, and only in comment lines.
+    Lowercase members and bare prose nouns are too noisy to be worth flagging.
+  * A reference is skipped when its *comment block* frames it as history —
+    "previously", "replaced by", "extracted from", "the popover-era", and friends.
+    Writing down that something was deleted is good documentation, not rot, and the
+    marker is usually on a neighbouring line of the same doc block, so whole
+    contiguous blocks are evaluated together rather than line by line.
+  * A name is satisfied by any declaration or filename under Sources/, Tests/, or
+    the in-repo Packages/. Resolved dependency checkouts are deliberately excluded
+    so the result does not depend on build state.
+  * Anything left needs an entry in comment-symbols-allowlist.txt, which is for
+    names owned outside this repository: Apple frameworks, POSIX signals, launchd
+    plist keys, SonarCloud rules, the C# runner server.
+
+Usage: python3 scripts/check-comment-symbols.py
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+ALLOWLIST = ROOT / "scripts" / "comment-symbols-allowlist.txt"
+
+HISTORICAL = re.compile(
+    r"previous|legacy|removed|replaces|replaced|deleted|superseded|obsolete"
+    r"|pre-|pre\-|popover-era|main-branch|extracted from|used to|no longer"
+    r"|since removed|former|original|old |older |has been|migration|gone",
+    re.IGNORECASE,
+)
+BACKTICKED = re.compile(r"`([A-Z][A-Za-z0-9_]*)`")
+COMMENT = re.compile(r"^\s*(///|//)")
+
+
+def search_roots():
+    """Sources, Tests, and the in-repo Packages/ only.
+
+    Deliberately excludes .build/checkouts: whether resolved dependencies are on
+    disk depends on build order, so including them makes the result differ between
+    a warm working copy and a clean CI checkout. Symbols owned by a *remote*
+    dependency belong in the allowlist instead.
+    """
+    roots = [ROOT / "Sources", ROOT / "Tests", ROOT / "Packages"]
+    return [r for r in roots if r.is_dir()]
+
+
+def build_corpus(roots):
+    """Every name that counts as existing: declarations plus file basenames."""
+    code, filenames = [], set()
+    for root in roots:
+        for path in root.rglob("*.swift"):
+            filenames.add(path.stem)
+            try:
+                text = path.read_text(errors="replace")
+            except OSError:
+                continue
+            code.extend(l for l in text.splitlines() if not COMMENT.match(l))
+    return set(re.findall(r"\b[A-Z][A-Za-z0-9_]*\b", "\n".join(code))) | filenames
+
+
+def comment_blocks(path):
+    """Yield (start_line, [lines]) for each run of contiguous comment lines."""
+    lines = path.read_text(errors="replace").splitlines()
+    block, start = [], 0
+    for i, line in enumerate(lines, 1):
+        if COMMENT.match(line):
+            if not block:
+                start = i
+            block.append((i, line))
+        elif block:
+            yield start, block
+            block = []
+    if block:
+        yield start, block
+
+
+def main():
+    allow = set()
+    if ALLOWLIST.exists():
+        allow = {
+            l.strip()
+            for l in ALLOWLIST.read_text().splitlines()
+            if l.strip() and not l.startswith("#")
+        }
+
+    known = build_corpus(search_roots())
+    offenders = {}
+
+    for target in ("Sources", "Tests"):
+        for path in (ROOT / target).rglob("*.swift"):
+            for _, block in comment_blocks(path):
+                if HISTORICAL.search(" ".join(l for _, l in block)):
+                    continue
+                for lineno, line in block:
+                    for name in BACKTICKED.findall(line):
+                        if name in allow or name in known:
+                            continue
+                        rel = path.relative_to(ROOT)
+                        offenders.setdefault(name, []).append(
+                            f"{rel}:{lineno}: {line.strip()[:110]}"
+                        )
+
+    if not offenders:
+        print(f"ok: no comment references unknown symbols ({len(known)} known names)")
+        return 0
+
+    print("error: comments reference symbols that do not exist:\n")
+    for name in sorted(offenders):
+        print(f"  {name}")
+        for hit in offenders[name][:4]:
+            print(f"      {hit}")
+    print(
+        "\nFix the reference, phrase it as history (\"replaced by …\"), or — only for\n"
+        f"names owned outside this repo — add it to {ALLOWLIST.relative_to(ROOT)}."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/comment-symbols-allowlist.txt
+++ b/scripts/comment-symbols-allowlist.txt
@@ -1,0 +1,18 @@
+# Symbols that comments may reference even though they are not declared in this
+# repository. Add a name here ONLY when it is owned somewhere else — an Apple
+# framework, the Swift standard library, a POSIX constant, a launchd plist key,
+# an external analyser rule, or the GitHub Actions runner server.
+#
+# Do NOT add a name here to silence a reference to something this repo deleted.
+# Either fix the reference or phrase it as history ("replaced by …"); see #3029.
+
+# Swift standard library / concurrency
+TaskGroup
+NaN
+
+# Foundation / AppKit
+AnyCodable
+NSUserDefaultsDidChangeNotification
+
+# Generic placeholders used in prose rather than as real types
+Value


### PR DESCRIPTION
Closes #3029
Stacked on: `fix-migrate-to-app-shell-step-37`

## What

**Comment-only change.** No executable code is added or altered. The only diff line that isn't a comment is a trailing comment on an otherwise byte-identical declaration:

```bash
git diff -U0 -- '*.swift' | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | sed 's/^[+-]//;s/^[[:space:]]*//' | grep -vE '^(//|///|$)'
```
returns only the two halves of that one line.

Follows the precedent set by #2987, which restored the shell sizing contracts after the same migration.

## Why

The AppShell migration (#3017 → #3026) moved the code and left the comments behind. **76 comment lines across 37 files named types that no longer exist.**

The count isn't the problem — *which* comments is. The two most emphatic `DO NOT REMOVE THIS COMMENT … major major major` blocks in the repo both described an NSPopover/NSPanel architecture that is gone, and one of them lived in a file Periphery reports as dead. A guard whose stated reason is falsifiable is worse than no guard: the next reader checks the claim, finds nothing, and discounts the whole block.

## Tier 1 — comments that would have caused a wrong change

| Where | Was | Now |
|---|---|---|
| `StepLogView.swift` | 30-line LAYOUT + SIZING CONTRACT naming `PopoverMainView`, `JobDetailView`, `AppDelegate.sizeObservation`, `NSHostingController`/`preferredContentSize` KVO — none of which exist — in a file Periphery reports unused | Contract **migrated** into `StepLogContentView.body`, restated for the windowed shell. `StepLogView` is marked superseded and points at the canonical copy |
| `ColorTokens.swift` | TRANSLUCENCY CONTRACT citing `NSVisualEffectView`, `.hudWindow`, `NSGlassEffectView`, `PanelChrome` | Restated in terms of `.glassEffect(.regular)` in `SurfaceModifiers`, which is what actually paints the backdrop |
| `RunBotRuntime.swift` | Deferred the #1741 ordering rule to the deleted `AppDelegate+StoreSetup.swift`; four comparisons to the deleted `AppState` | Rule **inlined** (this type is now its only home); `AppState` comparisons dropped |
| `Package.swift` | Explicit `GitHubClient` dependency justified by `AppDelegate+StoreSetup.swift` calling `configureGHAPI`/`configureGHRaw`/`configureGHAPIPaginated`/`configureGHLogger` — the file and **all four functions** are gone | Justified by the real usage: `RunBotRuntime` constructs `GitHubClient`/`OAuthCredentialController`, `RunBotApp` reads `GitHubConstants`, ~20 UI files import it |
| `TestDoubles.swift`, `RunnerViewModelProtocol.swift` | Sent readers to `FakeScopePreferencesStore` in `ScopeEditSheetTests.swift` and to `MockRunnerViewModel` — all deleted | Says plainly that no stateful double exists and one must be written |
| `LogCopyButton.swift` | "shared by ActionDetailView, JobDetailView, and StepLogView" — the stated reason for the type existing | One consumer, named accurately |

The important sequencing point: **the StepLog contract is migrated here, so #3027/#3028 can now delete `StepLogView.swift` without losing it.**

## Tier 2 — docs that were wrong about their own code

- `RunBotRuntime.runnerStore` was documented as "`nil` until `start()`". It is assigned unconditionally in `init()` and is never nil; the `guard let` in `start()` is defensive only.
- `onSignIn`/`onSignOut` were documented as behavioural hooks. Neither is read (Periphery flags both). Now documented as unread, with a pointer to wire-or-drop. **Left as a doc fix deliberately** — wiring them is a behaviour change and doesn't belong in a comment-only PR.
- Documented `runAttempt`, `cacheGroup`, `diskZIPCache`, `shaKeyedCache`, and `formatElapsed`'s injectable `now`. The `diskZIPCache` note records a real trap: pass it *and* `zipPrefetchQueue` and the two carry different caches.
- Repaired a corrupted `logFetcher` doc block in `StepLogContentView` — a dangling sentence fragment plus a duplicated two-line summary. Not in the audit; found while editing.
- Replaced the `FetchStepLogTests` coverage map (listed 4 tests that no longer existed, omitted 6 that did) with coverage *areas*, which don't rot when a test is renamed. Every test already has a descriptive `@Test("…")` name, so the map was duplicating a source of truth that had drifted away from it.

## Tier 3 — rationale that was missing entirely

`AddRunnerSheet.register()` spent 12 lines on `@MainActor` isolation and zero on what it guards. Added:

- **The containment guard** (`:376-383`) — a symlink-escape check with no comment at all. Two details are load-bearing and read as redundant: symlinks are resolved on *both* sides, and the prefix test is `homeDir + "/"` rather than `hasPrefix(homeDir)`, which would also admit sibling paths.
- The silent already-registered return (looks like a missing error path; it isn't), the idempotent download skip, and the deliberate `try?` on tarball cleanup.
- `RunnerLifecycleService.remove()`: `svc.sh` being non-fatal was recorded only inside a log string, so the obvious "fix" is to propagate the failure — which would strand runners as registered on GitHub with no local way to remove them.

## Guardrail

`scripts/check-comment-symbols.py` fails when a comment names a backticked type with no declaration or filename anywhere in `Sources/`, `Tests/`, or `Packages/`. Design notes:

- **Comment *blocks*, not lines.** Historical framing ("replaced by", "extracted from", "the popover-era") is usually on a neighbouring line of the same doc block. Writing down that something was deleted is good documentation, not rot.
- **Deterministic.** `.build/checkouts` is deliberately excluded — including it made the result differ between a warm working copy and a clean CI checkout. Verified identical output with and without it.
- **Allowlist is narrow** and documented as being only for names owned elsewhere (stdlib, Foundation), explicitly not for silencing references to things this repo deleted.

It earns its place immediately: it found **20 present-tense references to `RunnerStore`** (the pre-rename name of `RunnerPoller`) that my own audit in #3029 had misfiled as historical. Verified it catches a regression and goes green again when reverted. Wired into CI as `.github/workflows/comment-symbols.yml` and added to the AGENTS.md command list.

## Beyond the issue's scope — flagging for your call

**`AGENTS.md` had the same rot**, and it's the file agents read first, so I corrected it: all six `docs/` paths it points to are missing (the real files are `docs/architecture.md` and `docs/principles.md`), `ghAPIPaginated`/`GitHubTokenCache`/`GitHubTransportShimTests`/`PanelMainView`/`PanelVisibilityState` don't exist, and "Menu-bar-only (no Dock icon)" no longer describes the app. Happy to split this out if you'd rather keep the PR strictly to `Sources/`.

## What I deliberately did not do

- **Tier 4 (comment noise).** Five identical `/// The view body.` docs exist only to satisfy `missing_docs`. Changing that means editing `.swiftlint.yml`, which is scope creep here.
- **`AddRunnerSheet+FormFields.swift` MARKs.** My audit flagged it on a MARKs-per-line metric; reading it, the 6 MARKs are already at the real boundaries. The metric was misleading and there was nothing to fix. Only `ProcessRunner`'s `Result` type had a genuine gap.
- **Any dead-code deletion.** That's #3027/#3028.
- **Revalidating the popover-era UI-test and sheet-placement rules** in `RunBotUITests.swift` and `AddScopeSheet.swift`. Those need the self-hosted runner. I marked both as unrevalidated rather than silently rewriting rules I can't test or deleting guards that may still matter.

## Validation

| Gate | Result |
|---|---|
| `swift build` | pass |
| `swift test` | pass — 118 tests / 27 suites |
| `swiftlint lint --strict` | pass — 0 violations in 170 files |
| `periphery scan` | exit 0 — same 28 pre-existing findings as before, none added |
| `python3 scripts/check-comment-symbols.py` | pass — 1083 known names |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale code comments left by the AppShell migration (#3017→#3026) so regression guards describe code that actually exists. Comment-only change across 37 files — 76 lines referenced deleted types, including two "DO NOT REMOVE" guards describing an NSPopover/NSPanel architecture that has been gone for two architecture generations. A guard whose stated reason is falsifiable is worse than none. Closes #3029.

**Comment rewrites**
- Migrated the StepLog LAYOUT + SIZING CONTRACT from the now-dead `StepLogView` into `StepLogContentView.body`, restated for the windowed shell — so the #3027/#3028 dead-code cleanup can delete `StepLogView` without losing the rules.
- Restated the `ColorTokens` translucency contract in terms of `.glassEffect`; the cited `NSVisualEffectView` / `PanelChrome` / `.hudWindow` exist nowhere in the tree.
- Inlined the #1741 startup-ordering rule into `RunBotRuntime` (its only remaining home) and corrected the `Package.swift` dependency rationale, whose cited file and four functions are gone.
- Fixed docs wrong about their own code: `runnerStore` is never nil, `onSignIn`/`onSignOut` are unread, pointers to deleted test fixtures removed, and the stale `FetchStepLogTests` coverage map (4 deleted tests listed, 6 real ones omitted) replaced with coverage areas that don't rot on rename.
- Documented previously-unexplained behavior: `AddRunnerSheet`'s home-directory containment guard, its silent already-registered return, and the deliberately non-fatal `svc.sh` step in `RunnerLifecycleService.remove()`.

**Guardrail**
- Added `scripts/check-comment-symbols.py`, which fails when a comment references a backticked type with no declaration or filename. Blocks framed as history are allowed; `.build/checkouts` is excluded so CI results don't depend on build state. Wired into a new CI workflow and `AGENTS.md`.
- Corrected `AGENTS.md`, which pointed at six missing `docs/` paths and described the app as menu-bar-only.

Deliberately not done: Tier-4 comment noise (five identical `/// The view body.` docs), any dead-code deletion (that's #3027/#3028), and revalidation of popover-era UI-test and sheet-placement rules, which need the self-hosted runner — both sets are marked as unrevalidated instead.

<sup>Written for commit 8e7c795335ace7049077e84cbff096d8166f25c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Replace stale AppShell-era documentation with accurate guidance and add CI protection against future references to deleted symbols.

New Features:
- Add a comment-symbol validation script that detects references to unknown repository types and historical exceptions.
- Run the comment-symbol validation automatically in CI.

Bug Fixes:
- Correct stale documentation and comments left behind by the AppShell migration, including obsolete type names, removed UI architecture, and inaccurate lifecycle descriptions.
- Restore the step-log sizing contract in its live windowed-shell location and clarify retained but superseded code.
- Document load-bearing runner registration and removal safeguards to prevent misleading future changes.

Enhancements:
- Update project guidance and code comments to reflect the windowed AppShell, current GitHub client usage, RunnerPoller architecture, and existing test doubles and caches.
- Replace brittle test coverage listings with durable coverage-area documentation and clarify known unvalidated UI-test assumptions.

CI:
- Add a GitHub Actions workflow to check comments for references to deleted symbols.

Documentation:
- Correct stale paths, component names, architecture references, and UI guidance in AGENTS.md and throughout the source documentation.

Chores:
- Add a narrow allowlist for external symbols accepted by the comment validator.